### PR TITLE
[✨feat] 드롭다운 기능 구현 및 header 리팩토링

### DIFF
--- a/src/shared/components/header.tsx
+++ b/src/shared/components/header.tsx
@@ -1,26 +1,42 @@
 'use client';
 
-import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import React, { useEffect, useRef, useState } from 'react';
 
 const Header: React.FC = () => {
-  const isLoggedIn = false; // 임시코드 (로그인, 비로그인 확인용)
+  const isLoggedIn = true; // 임시코드 (로그인, 비로그인 확인용)
+  const [openDropdown, setOpenDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setOpenDropdown(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleLogout = () => {
+    console.log('로그아웃 처리');
+    setOpenDropdown(false);
+  };
 
   return (
-    <nav className="w-full max-w-[192rem] mx-auto h-[4.8rem] md:h-[6rem] px-[2.4rem] py-[0.6rem] md:px-[3rem] md:py-[1rem] lg:px-[20rem] bg-sub flex justify-between items-center">
-     
+    <nav className="bg-sub mx-auto flex h-[4.8rem] w-full items-center justify-between px-[2.4rem] py-[0.6rem] md:h-[6rem] md:px-[3rem] md:py-[1rem] lg:px-[20rem]">
       <div className="text-main txt-20-bold cursor-pointer md:flex md:gap-3">
-        <Image
-          src="/images/icons/logo.svg"
-          alt="Logo"
-          width={29}
-          height={24}
-        />
-        <span className='text-[#188FFF] txt-20-bold hidden md:block'>NOMADIA</span>
+        <Image src="/images/icons/logo.svg" alt="Logo" width={29} height={24} />
+        <span className="txt-20-bold hidden text-[#188FFF] md:block">
+          NOMADIA
+        </span>
       </div>
-      
-      <ul className="text-gray-950 txt-14-medium flex space-x-12">
+
+      <ul className="txt-14-medium flex space-x-12 text-gray-950">
         {isLoggedIn ? (
           <>
             {/* 로그인 상태일 때 */}
@@ -32,28 +48,59 @@ const Header: React.FC = () => {
                 height={19}
               />
             </li>
-            <span className='text-gray-100'>|</span>
-            <li className='flex items-center gap-2'>
-              <Image
-                src="/images/icons/profile.svg"
-                alt="프로필"
-                width={24}
-                height={24}
-                className="w-6 h-6 rounded-full"
-              />
-              <span className="text-gray-950 txt-14-medium">정만철</span>
+
+            <li className="text-gray-100">|</li>
+
+            {/* 프로필 + 드롭다운 */}
+            <li className="relative">
+              <button
+                className="flex items-center gap-5"
+                onClick={() => setOpenDropdown((prev) => !prev)}
+              >
+                <Image
+                  src="/images/icons/profile.svg"
+                  alt="프로필"
+                  width={24}
+                  height={24}
+                  className="h-6 w-6 rounded-full"
+                />
+                <span className="txt-14-medium text-gray-950">정만철</span>
+              </button>
+
+              {/* 드롭다운 메뉴 */}
+              {openDropdown && (
+                <div ref={dropdownRef} className="absolute">
+                  <button
+                    onClick={handleLogout}
+                    className="block w-full hover:bg-gray-100"
+                  >
+                    로그아웃
+                  </button>
+                  <Link
+                    href="/mypage"
+                    className="block py-2 hover:bg-gray-100"
+                    onClick={() => setOpenDropdown(false)}
+                  >
+                    마이페이지
+                  </Link>
+                </div>
+              )}
             </li>
           </>
         ) : (
           <>
             {/* 비로그인 상태일 때 */}
-        <li>
-          <Link href="/login" className="">로그인</Link>
-        </li>
-        <li>
-          <Link href="/signup" className="">회원가입</Link>
-        </li>
-        </>
+            <li>
+              <Link href="/login" className="">
+                로그인
+              </Link>
+            </li>
+            <li>
+              <Link href="/signup" className="">
+                회원가입
+              </Link>
+            </li>
+          </>
         )}
       </ul>
     </nav>


### PR DESCRIPTION
## ✨ 요약

 - 로그인 상태의 header에서 프로필 클릭 시 dropdown 열림
 - dropdown 기능 외 header.tsx 리팩토링

## 📝 상세 내용

 - dropdown 기능 구현
 - 로그아웃, 마이페이지 버튼 구현
 - 로그아웃 버튼은 현재 가상 로그인 상태이기 때문에 작동 x
 - dropdown 관련 ui는 따로 pr 추가 예정

 - max width 값 제거

## 🖼️ 스크린샷

<img width="158" height="152" alt="image" src="https://github.com/user-attachments/assets/aa81ca72-677b-4120-890b-40adf2f781a9" />

## ✅ 체크리스트

- '로고 버튼'을 클릭하면 메인 페이지로 이동합니다. ( X )
- 오른쪽 이름을 누르면 드롭 다운으로 '로그아웃' 버튼, '마이 페이지' 버튼이 보입니다. ( O )
- '로그아웃' 버튼을 클릭하면 로그아웃이 됩니다. ( O )
- '마이 페이지' 버튼을 클릭하면 마이 페이지로 이동합니다. ( O )
- '알림' 버튼을 클릭하면 나에게 온 알림 내역이 나타납니다. ( X )

## 💡 참고 사항

 - 로고 버튼 클릭 시 메인 페이지로 이동 구현은 dropdown ui 와 함께 올리겠습니다.
 - 알림 내역은 따로 작업 후 pr 올리도록 하겠습니다.
