### PR TITLE
[✨ Feat] 메인화면 UI 개발 (모든 체험)

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -5,10 +5,12 @@ import BestActivities from '@/features/activities/components/best-activities';
 const ActivitiesPage = () => {
   return (
     <main className="bg-background flex w-full flex-col gap-10">
-      <BannerCarousel />
-      {/* <Search /> */}
-      <BestActivities />
-      <AllActivities />
+      <div className="mx-auto w-full max-w-[120rem]">
+        <BannerCarousel />
+        {/* <Search /> */}
+        <BestActivities />
+        <AllActivities />
+      </div>
     </main>
   );
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,6 +75,8 @@
   --color-sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --color-sidebar-border: oklch(0.92 0.004 286.32);
   --color-sidebar-ring: oklch(0.705 0.015 286.067);
+  --color-gray-border: oklch(0.8822 0 0); /* #d8d8d8 */
+  --color-gray-hover: oklch(0.3211 0 0); /* #333333 */
 
   /* radius 변수들 */
   --radius-sm: calc(var(--radius) - 4px);
@@ -184,6 +186,15 @@
 @layer utilities {
   .flex-center {
     @apply flex items-center justify-center;
+  }
+
+  /* 카테고리 스크롤바 숨기기 */
+  .category-scroll {
+    -ms-overflow-style: none; /* IE, Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+  .category-scroll::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
   }
 
   /* #E9F7FF -> #FFFFFF */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import LandingPage from '@/features/landing/components/landing-page';
 
-
 const Page = () => {
   return (
     <main>
@@ -12,4 +11,3 @@ const Page = () => {
 };
 
 export default Page;
-

--- a/src/features/activities/components/activity-card.tsx
+++ b/src/features/activities/components/activity-card.tsx
@@ -13,6 +13,7 @@ interface ActivityCardProps {
 
 /**
  * 액티비티 카드 컴포넌트
+ * @author 김영현
  * @param activity - 액티비티 데이터
  * @param className - 추가 스타일 클래스
  */
@@ -20,8 +21,12 @@ export const ActivityCard = ({
   activity,
   className = '',
 }: ActivityCardProps) => (
+  // <Link
+  //   href={`/activities/${activity.id}`}
+  //   aria-label={`${activity.title} 상세 페이지로 이동`}
+  // >
   <div
-    className={`mb-[2.4rem] flex h-[24.3rem] w-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg md:mb-[8rem] ${className}`}
+    className={`flex h-[24.3rem] w-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg ${className}`}
   >
     {/* 이미지 영역 */}
     <div className="relative aspect-[4/3] w-full overflow-hidden">
@@ -61,4 +66,5 @@ export const ActivityCard = ({
       </div>
     </div>
   </div>
+  // </Link>
 );

--- a/src/features/activities/components/activity-card.tsx
+++ b/src/features/activities/components/activity-card.tsx
@@ -21,43 +21,44 @@ export const ActivityCard = ({
   activity,
   className = '',
 }: ActivityCardProps) => (
-  // <Link
-  //   href={`/activities/${activity.id}`}
-  //   aria-label={`${activity.title} 상세 페이지로 이동`}
-  // >
   <div
-    className={`flex h-[24.3rem] w-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg ${className}`}
+    className={`flex h-[24.3rem] w-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg md:h-[42.3rem] md:rounded-[2.6rem] lg:h-[36.6rem] ${className}`}
   >
     {/* 이미지 영역 */}
-    <div className="relative aspect-[4/3] w-full overflow-hidden">
+    <div className="relative aspect-[4/3] w-full overflow-hidden md:-mb-[2.6rem] md:aspect-11/10 lg:aspect-[3/4]">
       <Image
         src={activity.bannerImageUrl}
         alt={activity.title}
         fill
-        className="rounded-t-3xl object-cover"
+        className="rounded-t-3xl object-cover md:rounded-t-[2.6rem]"
         sizes="(max-width: 768px) 50vw, 25vw"
         priority={false}
       />
     </div>
+
     {/* 콘텐츠 영역 */}
-    <div className="flex flex-1 flex-col justify-between p-[1.25rem]">
-      {/* 제목 */}
-      <h3 className="mb-2 line-clamp-2 text-[1.4rem] leading-[1.8rem] font-semibold text-gray-900">
-        {activity.title}
-      </h3>
-      {/* 별점과 리뷰 */}
-      <div className="mb-2 flex items-center gap-1">
-        <Star className="text-yellow h-[1.125rem] w-[1.125rem] md:h-[2rem] md:w-[2rem]" />
-        <span className="text-[1.2rem] font-medium text-gray-950 md:text-[1.4rem]">
-          {activity.rating}
-        </span>
-        <span className="text-[1.2rem] font-medium text-gray-400 md:text-[1.4rem]">
-          ({activity.reviewCount})
-        </span>
+    <div className="flex flex-1 flex-col px-[1.7rem] py-[1.2rem] md:z-10 md:rounded-t-[2.6rem] md:bg-white md:px-[3rem] md:py-[1rem]">
+      {/* 제목과 별점 그룹 */}
+      <div className="flex flex-col gap-[0.4rem] md:mt-[1.4rem] md:gap-[0.6rem]">
+        {/* 제목 */}
+        <h3 className="text-gray-900md:overflow-hidden line-clamp-1 text-[1.4rem] leading-[1.8rem] font-semibold md:text-[1.8rem] md:text-ellipsis md:whitespace-nowrap">
+          {activity.title}
+        </h3>
+        {/* 별점과 리뷰 */}
+        <div className="flex items-center gap-[0.2rem] md:gap-[0.3rem]">
+          <Star className="text-yellow h-[1.25rem] w-[1.25rem] md:h-[2rem] md:w-[2rem]" />
+          <span className="text-[1.2rem] font-medium text-gray-950 md:text-[1.4rem]">
+            {activity.rating}
+          </span>
+          <span className="text-[1.2rem] font-medium text-gray-400 md:text-[1.4rem]">
+            ({activity.reviewCount})
+          </span>
+        </div>
       </div>
+
       {/* 가격 */}
-      <div className="mt-2 flex items-baseline gap-1">
-        <span className="text-[1.5rem] leading-[1.8rem] font-bold text-gray-950">
+      <div className="mt-[2rem] flex items-baseline gap-1">
+        <span className="text-[1.5rem] leading-[1.8rem] font-bold text-gray-950 md:text-[1.8rem]">
           ₩ {formatPrice(activity.price)}
         </span>
         <span className="text-[1.2rem] font-semibold text-gray-400 md:text-[1.6rem]">
@@ -66,5 +67,4 @@ export const ActivityCard = ({
       </div>
     </div>
   </div>
-  // </Link>
 );

--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -150,6 +150,7 @@ const AllActivities = () => {
         totalPages={totalPages}
         currentPage={page}
         setPage={setPage}
+        className="flex-center mt-[2.4rem] mb-[16.5rem] md:mt-[3rem] md:mb-[27.7rem] lg:mb-[27.1rem]"
       />
     </div>
   );

--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -1,17 +1,158 @@
+'use client';
+
+import {
+  Binoculars,
+  BusFront,
+  Leaf,
+  Music,
+  Soup,
+  Volleyball,
+} from 'lucide-react';
+import { useState } from 'react';
+
+import { ActivityCard } from '@/features/activities/components/activity-card';
+import useResActivitiesQuery from '@/features/activities/libs/hooks/useResActivitiesQuery';
+import Pagination from '@/shared/components/pagination/pagination';
+import { Button } from '@/shared/libs/shadcn/components/ui/button';
+
+/**
+ * 모든 체험 컴포넌트
+ * @author 김영현
+ * @returns 모든 체험 컴포넌트
+ */
 const AllActivities = () => {
-  return <div>AllActivities</div>;
+  const [active, setActive] = useState('문화 · 예술');
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, isError, size } = useResActivitiesQuery({
+    sort: 'latest',
+    category: active,
+    page,
+  });
+
+  // 로딩 상태 처리 -> 추후 로딩 관련 스피너 추가 필요
+  if (isLoading) {
+    return <div className="py-12 text-center text-gray-400">로딩 중...</div>;
+  }
+
+  // 에러 상태 처리 -> 추후 에러 상태 관련 컴포넌트 추가 필요
+  if (isError) {
+    return (
+      <div className="py-12 text-center text-red-500">
+        데이터를 불러오는 중 오류가 발생했습니다.
+      </div>
+    );
+  }
+
+  const activities = data?.activities ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / size));
+
+  const handleCategoryChange = (category: string) => {
+    setActive(category);
+    setPage(1);
+  };
+
+  return (
+    <div className="px-[2.4rem] md:px-[3rem] lg:px-[4rem]">
+      <div className="mb-[1rem] flex items-center justify-between md:mb-[1.6rem] lg:mb-[2rem]">
+        <p className="flex items-center gap-2 text-[1.8rem] font-bold text-gray-950 md:text-[3.2rem]">
+          <span role="img" aria-label="모든 체험">
+            🛼
+          </span>{' '}
+          모든 체험
+        </p>
+        {/* 추후 드롭다운 영역 추가 */}
+      </div>
+
+      <div className="category-scroll -mx-[2.4rem] mb-[2.4rem] flex flex-nowrap gap-[0.8rem] overflow-x-auto px-[2.4rem] whitespace-nowrap md:mb-[3rem] md:gap-[2rem]">
+        <Button
+          variant={active === '문화 · 예술' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('문화 · 예술')}
+        >
+          <Music
+            className={`size-[1.7rem] ${active === '문화 · 예술' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          문화 · 예술
+        </Button>
+
+        <Button
+          variant={active === '식음료' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('식음료')}
+        >
+          <Soup
+            className={`size-[1.7rem] ${active === '식음료' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          식음료
+        </Button>
+
+        <Button
+          variant={active === '스포츠' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('스포츠')}
+        >
+          <Volleyball
+            className={`size-[1.7rem] ${active === '스포츠' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          스포츠
+        </Button>
+
+        <Button
+          variant={active === '투어' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('투어')}
+        >
+          <Binoculars
+            className={`size-[1.7rem] ${active === '투어' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          투어
+        </Button>
+
+        <Button
+          variant={active === '관광' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('관광')}
+        >
+          <BusFront
+            className={`size-[1.7rem] ${active === '관광' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          관광
+        </Button>
+
+        <Button
+          variant={active === '웰빙' ? 'selected' : 'default'}
+          size="sm"
+          className="group"
+          onClick={() => handleCategoryChange('웰빙')}
+        >
+          <Leaf
+            className={`size-[1.7rem] ${active === '웰빙' ? 'text-white' : 'text-gray-950'}`}
+          />{' '}
+          웰빙
+        </Button>
+      </div>
+
+      <div>
+        <div className="grid grid-cols-2 gap-x-[1.8rem] gap-y-[2.4rem] md:gap-x-6 md:gap-y-[2.4rem] lg:grid-cols-4 lg:gap-x-[3rem] lg:gap-y-[2.4rem]">
+          {activities.map((activity) => (
+            <ActivityCard key={activity.id} activity={activity} />
+          ))}
+        </div>
+      </div>
+      <Pagination
+        totalPages={totalPages}
+        currentPage={page}
+        setPage={setPage}
+      />
+    </div>
+  );
 };
 
 export default AllActivities;
-
-/**
- * 여기서 const [page, setPage] = useState(1); 이런식으로 페이지를 관리하고, 
- * 
- * const fetchActivities = async (pageNumber: number) => {
-  const response = await api.getActivities({ page: pageNumber });
-  setActivities(response.activities);
-
-  이렇게 작성해서 페이지네이션 컴포넌트를 불러오면 내가 페이지네이션 컴포넌트로 page값을 넘겨주고 페이지가 바뀌면 다음 페이지 영역만큼 api 재호출
-  하는 느낌?
-};
- */

--- a/src/features/activities/components/best-activities.tsx
+++ b/src/features/activities/components/best-activities.tsx
@@ -51,7 +51,7 @@ const BestActivities = () => {
   };
 
   return (
-    <div className="px-[2.4rem] md:px-[3rem] lg:px-[4rem]">
+    <div className="mt-[4rem] px-[2.4rem] md:mt-[6rem] md:px-[3rem] lg:px-[4rem]">
       <div className="mb-[4rem] flex items-center justify-between md:mb-[1.6rem] lg:mb-[2rem]">
         <p className="flex items-center gap-2 text-[1.8rem] font-bold text-gray-950 md:text-[3.2rem]">
           <span role="img" aria-label="fire">

--- a/src/features/activities/components/best-activities.tsx
+++ b/src/features/activities/components/best-activities.tsx
@@ -12,6 +12,11 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { ActivityCard } from '@/features/activities/components/activity-card';
 import useActivity from '@/shared/libs/hooks/useActivityQuery';
 
+/**
+ * 인기 체험 컴포넌트
+ * @author 김영현
+ * @returns 인기 체험 컴포넌트
+ */
 const BestActivities = () => {
   const swiperRef = useRef<SwiperType | null>(null);
 
@@ -101,7 +106,10 @@ const BestActivities = () => {
         >
           {activities.map((activity) => (
             <SwiperSlide key={activity.id}>
-              <ActivityCard activity={activity} />
+              <ActivityCard
+                activity={activity}
+                className="mb-[2.4rem] md:mb-[8rem]"
+              />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/src/features/activities/libs/hooks/useResActivitiesQuery.ts
+++ b/src/features/activities/libs/hooks/useResActivitiesQuery.ts
@@ -33,7 +33,7 @@ const useResActivitiesQuery = (params: ResponsiveParams) => {
   const queryResult = useQuery<GetActListApiResponse>({
     queryKey: ['activities', { ...params, size }],
     queryFn: () => getActListApi({ ...params, size }),
-    staleTime: 1000 * 60,
+    staleTime: 1000 * 60 * 15,
     retry: 1,
   });
 

--- a/src/features/activities/libs/hooks/useResActivitiesQuery.ts
+++ b/src/features/activities/libs/hooks/useResActivitiesQuery.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { getActListApi } from '@/features/activities/libs/api/getActListApi';
+import {
+  GetActListApiParams,
+  GetActListApiResponse,
+} from '@/features/activities/libs/types/activity';
+
+type ResponsiveParams = Omit<GetActListApiParams, 'size'>;
+
+/**
+ * 모든 체험 목록 조회 훅 (all-activities.tsx)
+ * @author 김영현
+ * @param params - 모든 체험 목록 조회 파라미터
+ * @returns 모든 체험 목록 조회 결과
+ * @description 모바일, 태블릿, 데스크탑 환경에 따라 체험 목록 표시 개수 조정
+ */
+const useResActivitiesQuery = (params: ResponsiveParams) => {
+  const [size, setSize] = useState(6);
+
+  useEffect(() => {
+    const width = window.innerWidth;
+    if (width < 768) {
+      setSize(6);
+    } else if (width < 1024) {
+      setSize(4);
+    } else {
+      setSize(8);
+    }
+  }, []);
+
+  const queryResult = useQuery<GetActListApiResponse>({
+    queryKey: ['activities', { ...params, size }],
+    queryFn: () => getActListApi({ ...params, size }),
+    staleTime: 1000 * 60,
+    retry: 1,
+  });
+
+  return {
+    ...queryResult,
+    size,
+  };
+};
+
+export default useResActivitiesQuery;

--- a/src/features/activities/libs/types/activity.ts
+++ b/src/features/activities/libs/types/activity.ts
@@ -25,7 +25,7 @@ export interface GetActListApiResponse {
 export interface GetActListApiParams {
   category?: string;
   keyword?: string;
-  sort?: 'most_reviewed' | 'price_asc' | 'price_desc' | 'lastest';
+  sort?: 'most_reviewed' | 'price_asc' | 'price_desc' | 'latest';
   page?: number;
   size?: number;
 }

--- a/src/features/landing/components/experience-card.tsx
+++ b/src/features/landing/components/experience-card.tsx
@@ -7,6 +7,7 @@ import type { Experience } from '../libs/types/types';
 
 /**
  * 체험 카드 UI 컴포넌트
+ * @author 김영현
  * @param experience - 체험 정보 객체
  */
 const ExperienceCard = ({ experience }: { experience: Experience }) => (

--- a/src/shared/components/pagination/pagination.tsx
+++ b/src/shared/components/pagination/pagination.tsx
@@ -10,6 +10,7 @@ type PaginationProps = {
   totalPages: number;
   currentPage: number;
   setPage: React.Dispatch<React.SetStateAction<number>>;
+  className?: string;
 };
 
 /**
@@ -44,7 +45,12 @@ type PaginationProps = {
  * ```
  */
 
-const Pagination = ({ totalPages, currentPage, setPage }: PaginationProps) => {
+const Pagination = ({
+  totalPages,
+  currentPage,
+  setPage,
+  className = '',
+}: PaginationProps) => {
   if (totalPages <= 0) return null;
 
   const PAGE_GROUP_SIZE = 5;
@@ -61,7 +67,7 @@ const Pagination = ({ totalPages, currentPage, setPage }: PaginationProps) => {
   const rightDisable = pageGroupNum * PAGE_GROUP_SIZE >= totalPages;
 
   return (
-    <div className="flex">
+    <div className={cn('flex', className)}>
       <button
         onClick={() => {
           setPage((pageGroupNum - 1) * PAGE_GROUP_SIZE);

--- a/src/shared/libs/hooks/useActivityQuery.ts
+++ b/src/shared/libs/hooks/useActivityQuery.ts
@@ -6,7 +6,13 @@ import {
   GetActListApiResponse,
 } from '@/features/activities/libs/types/activity';
 
-// 랜딩페이지, 메인화면 배너, 인기 체험 컴포넌트에서 사용될 useActivity 훅
+/**
+ * 체험 목록 조회 훅
+ * @author 김영현
+ * @param params - 체험 목록 조회 파라미터
+ * @returns 체험 목록 조회 결과
+ * @description 랜딩페이지, 메인화면 배너, 인기 체험 컴포넌트에서 사용될 useActivity 훅
+ */
 const useActivity = (params: GetActListApiParams) => {
   return useQuery<GetActListApiResponse>({
     queryKey: ['activities', params],

--- a/src/shared/libs/hooks/useActivityQuery.ts
+++ b/src/shared/libs/hooks/useActivityQuery.ts
@@ -17,8 +17,10 @@ const useActivity = (params: GetActListApiParams) => {
   return useQuery<GetActListApiResponse>({
     queryKey: ['activities', params],
     queryFn: () => getActListApi(params),
-    staleTime: 1000 * 60,
+    staleTime: 1000 * 60 * 5,
     retry: 1,
+    refetchOnWindowFocus: false,
+    placeholderData: (previousData) => previousData,
   });
 };
 

--- a/src/shared/libs/shadcn/components/ui/button.tsx
+++ b/src/shared/libs/shadcn/components/ui/button.tsx
@@ -4,27 +4,37 @@ import * as React from 'react';
 
 import { cn } from '@/shared/libs/cn';
 
+/**
+ * 버튼 컴포넌트
+ * - selected 케이스 추가
+ * - default 케이스 수정
+ * - size 케이스 수정
+ * @author 김영현
+ */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+          'bg-white text-[1.4rem] border-1 border-gray-border font-medium text-gray-950 md:text-[1.6rem]',
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border bg-white shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
+        selected:
+          'text-[1.4rem] font-medium bg-gray-hover text-white border-1 border-gray-border md:text-[1.6rem]',
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        sm: 'h-[3rem] rounded-full gap-[0.4rem] px-[2rem] py-[2rem]',
+        md: 'h-[4rem] rounded-full gap-2 px-4 has-[>svg]:px-3',
+        lg: 'h-[4.4rem] rounded-full gap-2.5 px-5 has-[>svg]:px-4',
         icon: 'size-9',
       },
     },


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

- 메인화면의 모든 체험 UI 개발 (반응형 완료)
  - 버튼 눌렀을 때 `useResActivitiesQuery.ts` 에서 반응형 사이즈 별로 size를 불러와 보여줌
  - 아직 준우님이 개발 중이신 search, 필터 모달은 미적용 (19일 까지 적용 예정)

## 📝 상세 내용

  - 액티비티 카드 현재 제목(Title)은 12자가 넘어가면 "..." 으로 치환하여 보여줌 (추후 팀원분들과 논의 후 리팩토링 예정)
  - 페이지네이션 경우, staleTime을 15분으로 설정. (새롭게 불러오지 않아 빠름)
  
  - 모바일: 최대 6개씩 보여줌
  - 태블릿: 최대 4개씩 보여줌
  - PC: 최대 8개씩 보여줌

## 🖼️ 스크린샷

**[모바일]**

<img width="410" height="691" alt="image" src="https://github.com/user-attachments/assets/8ee7d8cc-77da-4f24-9379-29fe87f13c8f" />

---

**[태블릿]**

<img width="525" height="785" alt="image" src="https://github.com/user-attachments/assets/b5139d02-be2e-4a59-9a12-47f1c5807164" />
<img width="503" height="543" alt="image" src="https://github.com/user-attachments/assets/9460e6ae-23d2-4615-9977-a4bb7292f249" />


---

**[PC]**

<img width="1506" height="1116" alt="image" src="https://github.com/user-attachments/assets/98c3d849-d38c-400e-8544-49f319f66564" />


---

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
