### PR TITLE
[✨Feat] 메인화면 드롭다운 추가

### DIFF
--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -3,6 +3,7 @@
 import {
   Binoculars,
   BusFront,
+  ChevronDown,
   Leaf,
   Music,
   Soup,
@@ -12,6 +13,7 @@ import { useState } from 'react';
 
 import { ActivityCard } from '@/features/activities/components/activity-card';
 import useResActivitiesQuery from '@/features/activities/libs/hooks/useResActivitiesQuery';
+import Dropdown from '@/shared/components/dropdown';
 import Pagination from '@/shared/components/pagination/pagination';
 import { Button } from '@/shared/libs/shadcn/components/ui/button';
 
@@ -24,20 +26,34 @@ const CATEGORIES = [
   { name: '웰빙', icon: Leaf },
 ];
 
+const sortOptions = [
+  { label: '최신순', value: 'latest' },
+  { label: '낮은 가격순', value: 'price_asc' },
+  { label: '높은 가격순', value: 'price_desc' },
+];
+
+interface AllActivitiesProps {
+  keyword?: string;
+}
+
 /**
  * 모든 체험 컴포넌트
  * @author 김영현
  * @returns 모든 체험 컴포넌트
  * @description 모든 체험 목록을 표시하는 컴포넌트입니다.
  */
-const AllActivities = () => {
+const AllActivities = ({ keyword }: AllActivitiesProps) => {
   const [active, setActive] = useState('문화 · 예술');
   const [page, setPage] = useState(1);
+  const [selectedSort, setSelectedSort] = useState<
+    'latest' | 'price_asc' | 'price_desc' | 'most_reviewed'
+  >('latest');
 
   const { data, isLoading, isError, size } = useResActivitiesQuery({
-    sort: 'latest',
+    sort: selectedSort,
     category: active,
     page,
+    keyword,
   });
 
   // 로딩 상태 처리 -> 추후 로딩 관련 스피너 추가 필요
@@ -63,6 +79,13 @@ const AllActivities = () => {
     setPage(1);
   };
 
+  const handleSortChange = (
+    value: 'latest' | 'price_asc' | 'price_desc' | 'most_reviewed',
+  ) => {
+    setSelectedSort(value);
+    setPage(1);
+  };
+
   return (
     <div className="px-[2.4rem] md:px-[3rem] lg:px-[4rem]">
       <div className="mb-[1rem] flex items-center justify-between md:mb-[1.6rem] lg:mb-[2rem]">
@@ -72,7 +95,32 @@ const AllActivities = () => {
           </span>{' '}
           모든 체험
         </p>
-        {/* 추후 드롭다운 영역 추가 */}
+        <Dropdown
+          trigger={
+            <button className="txt-16-medium flex items-center text-black">
+              가격 <ChevronDown size={18} className="ml-1" />
+            </button>
+          }
+          dropdownClassName="absolute right-0"
+        >
+          <div className="border-sub-300 txt-16-medium h-[11rem] w-[11.2rem] overflow-hidden rounded-xl border-[0.1rem] bg-white">
+            {sortOptions.map(({ label, value }) => (
+              <button
+                key={value}
+                onClick={() =>
+                  handleSortChange(
+                    value as 'latest' | 'price_asc' | 'price_desc',
+                  )
+                }
+                className={`txt-14-medium w-full px-4 py-2 hover:bg-blue-50 ${
+                  selectedSort === value ? 'text-main font-bold' : 'text-black'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </Dropdown>
       </div>
 
       <div className="category-scroll -mx-[2.4rem] mb-[2.4rem] flex flex-nowrap gap-[0.8rem] overflow-x-auto px-[2.4rem] whitespace-nowrap md:mb-[3rem] md:gap-[2rem]">

--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -46,7 +46,7 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
   const [active, setActive] = useState('문화 · 예술');
   const [page, setPage] = useState(1);
   const [selectedSort, setSelectedSort] = useState<
-    'latest' | 'price_asc' | 'price_desc' | 'most_reviewed'
+    'latest' | 'price_asc' | 'price_desc'
   >('latest');
 
   const { data, isLoading, isError, size } = useResActivitiesQuery({
@@ -79,9 +79,7 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
     setPage(1);
   };
 
-  const handleSortChange = (
-    value: 'latest' | 'price_asc' | 'price_desc' | 'most_reviewed',
-  ) => {
+  const handleSortChange = (value: 'latest' | 'price_asc' | 'price_desc') => {
     setSelectedSort(value);
     setPage(1);
   };

--- a/src/shared/components/dropdown.tsx
+++ b/src/shared/components/dropdown.tsx
@@ -45,7 +45,7 @@ const Dropdown: React.FC<DropdownProps> = ({
       </div>
       {isOpen && (
         <div
-          className={`absolute mt-[1.5rem] ${dropdownClassName} ${className} `}
+          className={`absolute z-[9999] mt-[1.5rem] ${dropdownClassName} ${className} `}
         >
           {children}
         </div>


### PR DESCRIPTION
## ✨ 요약

 - 메인 화면 드롭다운 추가

## 📝 상세 내용

 - 드롭다운 z값 설정으로 페이지 맨 위로 올림
 - 모든 체험 카테고리와 가격 드롭다운을 동시에 만족하도록 정렬 됌

## 🖼️ 스크린샷

<img width="338" height="295" alt="image" src="https://github.com/user-attachments/assets/89301f8b-382d-4714-8d97-ca8c1aef62b3" />

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 활동 목록에서 정렬 기능이 추가되어, 최신순, 가격 오름차순/내림차순으로 정렬할 수 있는 드롭다운 메뉴가 제공됩니다.
  * 활동 검색 시 키워드를 입력해 필터링할 수 있습니다.

* **Style**
  * 드롭다운 메뉴가 항상 다른 요소 위에 표시되도록 시각적 계층(z-index)이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->