### PR TITLE
[🎨Style] 메인화면 드롭다운 ui 수정

### DIFF
--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -49,6 +49,10 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
     setPage(1);
   };
 
+  const selectedSortLabel = SORT_OPTIONS.find(
+    (option) => option.value === selectedSort,
+  )?.label;
+
   const handleSortChange = (value: 'latest' | 'price_asc' | 'price_desc') => {
     setSelectedSort(value);
     setPage(1);
@@ -65,13 +69,13 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
         </p>
         <Dropdown
           trigger={
-            <button className="txt-16-medium flex items-center text-black">
-              가격 <ChevronDown size={18} className="ml-1" />
+            <button className="txt-14-medium flex items-center text-black">
+              {selectedSortLabel} <ChevronDown size={20} className="ml-1" />
             </button>
           }
           dropdownClassName="absolute right-0"
         >
-          <div className="border-sub-300 txt-16-medium h-[11rem] w-[11.2rem] overflow-hidden rounded-xl border-[0.1rem] bg-white">
+          <div className="border-sub-300 txt-14-medium h-[12.3rem] w-[9.6rem] overflow-hidden rounded-xl border-[0.1rem] bg-white">
             {SORT_OPTIONS.map(({ label, value }) => (
               <button
                 key={value}
@@ -80,7 +84,7 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
                     value as 'latest' | 'price_asc' | 'price_desc',
                   )
                 }
-                className={`txt-14-medium w-full px-4 py-2 hover:bg-blue-50 ${
+                className={`txt-14-medium h-[4.1rem] w-full px-[1rem] py-[0.6rem] hover:bg-blue-50 ${
                   selectedSort === value ? 'text-main font-bold' : 'text-black'
                 }`}
               >


### PR DESCRIPTION
## ✨ 요약

 - 드롭다운 ui 수정

## 📝 상세 내용

 - 피그마 시안에서 rem 값을 좀 수정하여 디자인 수정을 마무리했습니다

## 🖼️ 스크린샷

모바일
<img width="178" height="171" alt="image" src="https://github.com/user-attachments/assets/5a77661b-c712-4f9a-b597-ce6a72fc509b" />

태블릿
<img width="132" height="155" alt="image" src="https://github.com/user-attachments/assets/c031463b-701e-4737-9267-9099482c5a0d" />

pc
<img width="575" height="231" alt="image" src="https://github.com/user-attachments/assets/7befed35-19c0-4c9f-865b-92c71b7cda4e" />


## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
