### PR TITLE
[✨Feat] 예약 현황 구현 - 1차

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 
 import { Providers } from '@/app/providers';
-import HeaderWrapper from '@/features/landing/components/header-wrapper';
 import Footer from '@/shared/components/footer';
+import HeaderWrapper from '@/shared/components/header-wrapper';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',

--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -133,7 +133,7 @@ const ReserveCalendarPage = () => {
             reservationArray={reservationArray}
             calendarWidth="md:w-[47.6rem] lg:w-[64rem] md:mt-[2.4rem] md:rounded-[2rem] border border-gray-50 shadow-experience-card"
             dayOfWeekStyle="w-[5.35rem] md:w-[6.8rem] lg:w-[9.143rem]"
-            onDateClick={handleDateClick}
+            onCellClick={handleDateClick}
           />
         ) : (
           <p className="mt-4 text-center text-gray-500">

--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -41,7 +41,7 @@ const ReserveCalendarPage = () => {
             <ChevronDown className="size-[2rem]" />
           </div>
         }
-        dropdownClassName="w-full bg-white shadow-lg rounded-[1rem] border border-gray-100"
+        dropdownClassName="w-full bg-white shadow-experience-card rounded-[1rem] border border-gray-100 px-[2.6rem]"
       >
         <ul className="py-3">
           <p>내가 등록한 체험1</p>

--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -3,58 +3,154 @@
 import { ChevronDown } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
+import { getActListApi } from '@/features/activities/libs/api/getActListApi';
+import { getReservationsByMonthApi } from '@/features/activities/libs/api/getReserveMonthApi';
 import CalendarWithReservations from '@/shared/components/calendar/components/calendar-with-reservations';
 import { MonthReservations } from '@/shared/components/calendar/libs/types/data';
 import Dropdown from '@/shared/components/dropdown';
+import BaseModal from '@/shared/components/modal/components/base-modal';
+import { useCalendarStore } from '@/shared/libs/stores/useCalendarStore';
+import { useModalStore } from '@/shared/libs/stores/useModalStore';
+import { Activity } from '@/shared/types/activity';
 
 const ReserveCalendarPage = () => {
   const [reservationArray, setReservationArray] = useState<MonthReservations[]>(
     [],
   );
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [selectedActivityTitle, setSelectedActivityTitle] =
+    useState<string>('내가 등록한 체험 선택');
+  const [selectedActivityId, setSelectedActivityId] = useState<string | null>(
+    null,
+  );
+  const [shouldFetch, setShouldFetch] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const { year, month } = useCalendarStore();
+  const { isModalOpen, openModal } = useModalStore();
+
+  const handleDropdownOpen = () => {
+    setShouldFetch(true);
+  };
+
+  const handleDateClick = (dateStr: string) => {
+    setSelectedDate(dateStr);
+    openModal();
+  };
 
   useEffect(() => {
-    const fetchReservations = async () => {
-      try {
-        // 체험 상세 예약 기능 완성 후 구현
-        const data: MonthReservations[] = [];
-        setReservationArray(data);
-      } catch (error) {
-        console.error('예약 데이터 가져오기 실패', error);
-      }
-    };
+    if (!shouldFetch) return;
 
-    fetchReservations();
-  }, []);
+    (async () => {
+      try {
+        const data = await getActListApi();
+        setActivities(data.activities || []);
+      } catch (error) {
+        console.error('내 체험 리스트 조회 실패', error);
+      }
+      setShouldFetch(false);
+    })();
+  }, [shouldFetch]);
+
+  const handleSelectActivity = (id: string | number, title: string) => {
+    setSelectedActivityTitle(title);
+    setSelectedActivityId(String(id));
+
+    const event = new MouseEvent('mousedown', {
+      view: window,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+  };
+
+  useEffect(() => {
+    if (!selectedActivityId) {
+      setReservationArray([]);
+      return;
+    }
+
+    (async () => {
+      try {
+        const reservations = await getReservationsByMonthApi({
+          activityId: selectedActivityId,
+          year,
+          month: month + 1,
+        });
+        setReservationArray(reservations);
+      } catch (error) {
+        console.error('내 체험 리스트 조회 실패', error);
+        setReservationArray([]);
+      }
+    })();
+  }, [selectedActivityId, year, month]);
 
   return (
     <div className="flex flex-1 flex-col">
       <div className="flex h-[6.8rem] flex-col gap-[1rem]">
         <h2 className="txt-18-bold text-gray-950">예약 현황</h2>
         <p className="txt-14-medium text-gray-500">
-          내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
+          내 체험의 내역들을 한 눈에 확인할 수 있습니다.
         </p>
       </div>
 
       <Dropdown
         trigger={
-          <div className="shadow-experience-card mt-[1.8rem] flex h-[5.4rem] w-full cursor-pointer items-center justify-end rounded-[1rem] border border-gray-100 bg-white pr-[2.6rem] text-[1.4rem] text-gray-950 md:text-[1.6rem]">
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleDropdownOpen}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleDropdownOpen();
+              }
+            }}
+            className="shadow-experience-card mt-[1.8rem] flex h-[5.4rem] w-full cursor-pointer items-center justify-end rounded-[1rem] border border-gray-100 bg-white pr-[2.6rem] text-[1.4rem] text-gray-950 md:text-[1.6rem]"
+          >
+            <span>{selectedActivityTitle}</span>
             <ChevronDown className="size-[2rem]" />
           </div>
         }
         dropdownClassName="w-full bg-white shadow-experience-card rounded-[1rem] border border-gray-100 px-[2.6rem]"
       >
         <ul className="py-3">
-          <p>내가 등록한 체험1</p>
-          <p>내가 등록한 체험2</p>
-          <p>내가 등록한 체험3</p>
+          {activities.length === 0 && <p>체험이 없습니다.</p>}
+          {activities.map((act) => (
+            <button
+              key={act.id}
+              className="block w-full cursor-pointer py-2 text-left hover:bg-gray-100"
+              onClick={() => handleSelectActivity(act.id, act.title)}
+            >
+              {act.title}
+            </button>
+          ))}
         </ul>
       </Dropdown>
 
       <div className="flex-center flex">
-        <CalendarWithReservations
-          reservationArray={reservationArray}
-          calendarWidth="md:w-[47.6rem] lg:w-[64rem] md:mt-[2.4rem] md:rounded-[2rem] border border-gray-50 shadow-experience-card"
-        />
+        {selectedActivityId ? (
+          <CalendarWithReservations
+            reservationArray={reservationArray}
+            calendarWidth="md:w-[47.6rem] lg:w-[64rem] md:mt-[2.4rem] md:rounded-[2rem] border border-gray-50 shadow-experience-card"
+            dayOfWeekStyle="w-[5.35rem] md:w-[6.8rem] lg:w-[9.143rem]"
+            onDateClick={handleDateClick}
+          />
+        ) : (
+          <p className="mt-4 text-center text-gray-500">
+            등록한 체험을 선택해주세요.
+          </p>
+        )}
+
+        {isModalOpen && selectedDate && (
+          <BaseModal
+            type="custom"
+            hasOverlay
+            isCenter
+            extraClassName="max-w p-6 rounded-xl"
+          >
+            <div />
+          </BaseModal>
+        )}
       </div>
     </div>
   );

--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -55,13 +55,6 @@ const ReserveCalendarPage = () => {
   const handleSelectActivity = (id: string | number, title: string) => {
     setSelectedActivityTitle(title);
     setSelectedActivityId(String(id));
-
-    const event = new MouseEvent('mousedown', {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-    });
-    document.dispatchEvent(event);
   };
 
   useEffect(() => {
@@ -113,18 +106,23 @@ const ReserveCalendarPage = () => {
         }
         dropdownClassName="w-full bg-white shadow-experience-card rounded-[1rem] border border-gray-100 px-[2.6rem]"
       >
-        <ul className="py-3">
-          {activities.length === 0 && <p>체험이 없습니다.</p>}
-          {activities.map((act) => (
-            <button
-              key={act.id}
-              className="block w-full cursor-pointer py-2 text-left hover:bg-gray-100"
-              onClick={() => handleSelectActivity(act.id, act.title)}
-            >
-              {act.title}
-            </button>
-          ))}
-        </ul>
+        {(close) => (
+          <ul className="py-3">
+            {activities.length === 0 && <p>체험이 없습니다.</p>}
+            {activities.map((act) => (
+              <button
+                key={act.id}
+                className="block w-full cursor-pointer py-2 text-left hover:bg-gray-100"
+                onClick={() => {
+                  handleSelectActivity(act.id, act.title);
+                  close();
+                }}
+              >
+                {act.title}
+              </button>
+            ))}
+          </ul>
+        )}
       </Dropdown>
 
       <div className="flex-center flex">

--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -1,11 +1,63 @@
-const ReserveCalenderPage = () => {
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+
+import CalendarWithReservations from '@/shared/components/calendar/components/calendar-with-reservations';
+import { MonthReservations } from '@/shared/components/calendar/libs/types/data';
+import Dropdown from '@/shared/components/dropdown';
+
+const ReserveCalendarPage = () => {
+  const [reservationArray, setReservationArray] = useState<MonthReservations[]>(
+    [],
+  );
+
+  useEffect(() => {
+    const fetchReservations = async () => {
+      try {
+        // 체험 상세 예약 기능 완성 후 구현
+        const data: MonthReservations[] = [];
+        setReservationArray(data);
+      } catch (error) {
+        console.error('예약 데이터 가져오기 실패', error);
+      }
+    };
+
+    fetchReservations();
+  }, []);
+
   return (
-    <div>
-      예약현황 페이지
-      <div className="bg-red-500">ㄴㄴ</div>
-      <button className="bg-main text-black">click</button>
+    <div className="flex flex-1 flex-col">
+      <div className="flex h-[6.8rem] flex-col gap-[1rem]">
+        <h2 className="txt-18-bold text-gray-950">예약 현황</h2>
+        <p className="txt-14-medium text-gray-500">
+          내 체험에 예약된 내역들을 한 눈에 확인할 수 있습니다.
+        </p>
+      </div>
+
+      <Dropdown
+        trigger={
+          <div className="shadow-experience-card mt-[1.8rem] flex h-[5.4rem] w-full cursor-pointer items-center justify-end rounded-[1rem] border border-gray-100 bg-white pr-[2.6rem] text-[1.4rem] text-gray-950 md:text-[1.6rem]">
+            <ChevronDown className="size-[2rem]" />
+          </div>
+        }
+        dropdownClassName="w-full bg-white shadow-lg rounded-[1rem] border border-gray-100"
+      >
+        <ul className="py-3">
+          <p>내가 등록한 체험1</p>
+          <p>내가 등록한 체험2</p>
+          <p>내가 등록한 체험3</p>
+        </ul>
+      </Dropdown>
+
+      <div className="flex-center flex">
+        <CalendarWithReservations
+          reservationArray={reservationArray}
+          calendarWidth="md:w-[47.6rem] lg:w-[64rem] md:mt-[2.4rem] md:rounded-[2rem] border border-gray-50 shadow-experience-card"
+        />
+      </div>
     </div>
   );
 };
 
-export default ReserveCalenderPage;
+export default ReserveCalendarPage;

--- a/src/features/activities/libs/api/getReserveMonthApi.ts
+++ b/src/features/activities/libs/api/getReserveMonthApi.ts
@@ -1,22 +1,15 @@
 import axios from 'axios';
 
+import { MonthReservations } from '@/shared/components/calendar/libs/types/data';
+
 interface FindReservationsByMonthParams {
   activityId: string;
   year: number;
   month: number;
 }
 
-export interface MonthReservation {
-  date: string;
-  reservations: {
-    completed: number;
-    confirmed: number;
-    pending: number;
-  };
-}
-
 interface FindReservationsByMonthResponse {
-  data: MonthReservation[];
+  data: MonthReservations[];
 }
 
 /**
@@ -28,7 +21,7 @@ export const getReservationsByMonthApi = async ({
   activityId,
   year,
   month,
-}: FindReservationsByMonthParams): Promise<MonthReservation[]> => {
+}: FindReservationsByMonthParams): Promise<MonthReservations[]> => {
   try {
     const response = await axios.get<FindReservationsByMonthResponse>(
       `https://sp-globalnomad-api.vercel.app/api/v1/my-activities/${activityId}/reservations/month`,

--- a/src/features/activities/libs/api/getReserveMonthApi.ts
+++ b/src/features/activities/libs/api/getReserveMonthApi.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+interface FindReservationsByMonthParams {
+  activityId: string;
+  year: number;
+  month: number;
+}
+
+export interface MonthReservation {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+}
+
+interface FindReservationsByMonthResponse {
+  data: MonthReservation[];
+}
+
+/**
+ * 내 체험 월별 예약 현황 조회 API 호출 함수
+ * @param params - activityId, year, month
+ * @returns 월별 예약 현황 배열
+ */
+export const getReservationsByMonthApi = async ({
+  activityId,
+  year,
+  month,
+}: FindReservationsByMonthParams): Promise<MonthReservation[]> => {
+  try {
+    const response = await axios.get<FindReservationsByMonthResponse>(
+      `https://sp-globalnomad-api.vercel.app/api/v1/my-activities/${activityId}/reservations/month`,
+      {
+        params: { year, month },
+      },
+    );
+
+    return response.data.data;
+  } catch (error) {
+    console.error('내 체험 월별 예약 현황 조회 실패', error);
+    throw error;
+  }
+};

--- a/src/features/landing/components/header-wrapper.tsx
+++ b/src/features/landing/components/header-wrapper.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import Header from '@/shared/components/header';
-
-export default function HeaderWrapper() {
-  return <Header />;
-}

--- a/src/shared/components/calendar/components/calendar-with-reservations.tsx
+++ b/src/shared/components/calendar/components/calendar-with-reservations.tsx
@@ -44,6 +44,7 @@ const CalendarWithReservations = ({
   calendarWidth?: string;
   dayOfWeekStyle?: string;
   cellStyle?: string;
+  onDateClick?: (dateStr: string) => void;
 }) => {
   const { year, month, date, setDate, setSelectedDate } = useCalendarStore();
   const { thisMonthDays } = getMonthRange(year, month);

--- a/src/shared/components/calendar/components/calendar-with-reservations.tsx
+++ b/src/shared/components/calendar/components/calendar-with-reservations.tsx
@@ -44,7 +44,7 @@ const CalendarWithReservations = ({
   calendarWidth?: string;
   dayOfWeekStyle?: string;
   cellStyle?: string;
-  onDateClick?: (dateStr: string) => void;
+  onCellClick?: (dateStr: string) => void;
 }) => {
   const { year, month, date, setDate, setSelectedDate } = useCalendarStore();
   const { thisMonthDays } = getMonthRange(year, month);

--- a/src/shared/components/calendar/components/days-of-month.tsx
+++ b/src/shared/components/calendar/components/days-of-month.tsx
@@ -20,7 +20,7 @@ const DaysOfMonth = ({
   const { leadingDays, trailingDays } = getMonthRange(year, month);
 
   return (
-    <>
+    <div className="grid w-full grid-cols-7">
       {/* 요일(일~토) */}
       <DayOfWeek dayOfWeekStyle={dayOfWeekStyle} />
       {/* 앞 달 날짜*/}
@@ -30,7 +30,7 @@ const DaysOfMonth = ({
       {/* 다음달 날짜*/}
       <NotThisMonth daysArray={trailingDays} cellStyle={inactiveCellStyle} />
       {/* </div> */}
-    </>
+    </div>
   );
 };
 export default DaysOfMonth;

--- a/src/shared/components/calendar/components/days-of-month.tsx
+++ b/src/shared/components/calendar/components/days-of-month.tsx
@@ -20,7 +20,7 @@ const DaysOfMonth = ({
   const { leadingDays, trailingDays } = getMonthRange(year, month);
 
   return (
-    <div className="grid w-full grid-cols-7">
+    <div className="grid grid-cols-7">
       {/* 요일(일~토) */}
       <DayOfWeek dayOfWeekStyle={dayOfWeekStyle} />
       {/* 앞 달 날짜*/}

--- a/src/shared/components/dropdown.tsx
+++ b/src/shared/components/dropdown.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 interface DropdownProps {
   trigger: React.ReactNode;
-  children: React.ReactNode;
+  children: React.ReactNode | ((close: () => void) => React.ReactNode);
   className?: string;
   dropdownClassName?: string;
 }
@@ -47,7 +47,9 @@ const Dropdown: React.FC<DropdownProps> = ({
         <div
           className={`absolute z-[9999] mt-[1.5rem] ${dropdownClassName} ${className} `}
         >
-          {children}
+          {typeof children === 'function'
+            ? children(() => setIsOpen(false))
+            : children}
         </div>
       )}
     </div>

--- a/src/shared/components/header-wrapper.tsx
+++ b/src/shared/components/header-wrapper.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import Header from '@/shared/components/header';
+
+const HeaderWrapper = () => <Header />;
+
+export default HeaderWrapper;


### PR DESCRIPTION
## ✨ 요약

 - 예약 현황 페이지 1차 작업

## 📝 상세 내용

 - 내 체험에 예약한 내역은 체험 상세 예약 완성 후 추가 예정
 - 캘린더, 드롭다운 컴포넌트 사용
 - 각 컴포넌트에 반응형 ui 적용

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항

 - 반응형 시 캘린더 내부 배열이 깨짐을 막고자 days-of-month.tsx 코드 수정했습니다.
  [ width 값을 항상 full로 받고, 달력 내 요소는 한 줄에 7개로 고정(grid-cols-7) ]

 - header-wrapper.tsx 파일 구조 변경에 따라 app/layout.tsx 코드 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약 캘린더 페이지가 클라이언트 사이드 컴포넌트로 개선되어 예약 데이터 표시, 드롭다운 메뉴, 캘린더 UI가 추가되었습니다.
  * 월별 예약 데이터를 조회하는 API 기능이 추가되었습니다.
  * 캘린더 컴포넌트에서 날짜 클릭 시 외부에서 이벤트를 처리할 수 있는 기능이 추가되었습니다.
  * 드롭다운 메뉴 내에서 프로그래밍적으로 닫기 기능을 호출할 수 있도록 개선되었습니다.

* **버그 수정**
  * 캘린더의 일자 표시가 7열 그리드 레이아웃으로 정렬되어 시각적으로 개선되었습니다.

* **리팩터**
  * HeaderWrapper 컴포넌트가 공용 디렉토리로 이동되었습니다.
  * 예약 캘린더 페이지 컴포넌트 이름이 오타에서 올바른 이름으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->