### PR TITLE
✨ feat: 체험 카드, 사진 클릭 시 체험 상세 페이지로 이동

### DIFF
--- a/src/features/activities/components/activity-card.tsx
+++ b/src/features/activities/components/activity-card.tsx
@@ -1,5 +1,6 @@
 import { Star } from 'lucide-react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 import { formatPrice } from '@/shared/libs/utils/formatPrice';
@@ -19,51 +20,69 @@ interface ActivityCardProps {
 export const ActivityCard = ({
   activity,
   className = '',
-}: ActivityCardProps) => (
-  <div
-    className={`shadow-experience-card flex h-[24.3rem] w-full flex-col overflow-hidden rounded-[1.2rem] bg-white md:h-[42.3rem] md:rounded-[2.6rem] lg:h-[36.6rem] ${className}`}
-  >
-    {/* 이미지 영역 */}
-    <div className="relative aspect-[3/4] w-full overflow-hidden md:-mb-[2.6rem] md:aspect-11/10 lg:aspect-[3/4]">
-      <Image
-        src={activity.bannerImageUrl}
-        alt={activity.title}
-        fill
-        className="rounded-t-3xl object-cover md:rounded-t-[2.6rem]"
-        sizes="(max-width: 768px) 50vw, 25vw"
-        priority={false}
-      />
-    </div>
+}: ActivityCardProps) => {
+  const router = useRouter();
 
-    {/* 콘텐츠 영역 */}
-    <div className="flex flex-1 flex-col rounded-[1.2rem] px-[1.7rem] py-[1.2rem] md:z-10 md:rounded-t-[2.6rem] md:bg-white md:px-[3rem] md:py-[2rem] lg:px-[2.8rem] lg:py-[2.4rem]">
-      {/* 제목과 별점 그룹 */}
-      <div className="mt-[0.5rem] flex flex-col gap-[0.6rem]">
-        {/* 제목 */}
-        <h3 className="line-clamp-1 text-[1.4rem] leading-[1.8rem] font-semibold text-gray-900 md:overflow-hidden md:text-[1.8rem] md:text-ellipsis md:whitespace-nowrap">
-          {activity.title}
-        </h3>
-        {/* 별점과 리뷰 */}
-        <div className="flex items-center gap-[0.2rem] md:gap-[0.3rem]">
-          <Star className="text-yellow h-[1.25rem] w-[1.25rem] md:h-[2rem] md:w-[2rem]" />
-          <span className="text-[1.2rem] font-medium text-gray-950 md:text-[1.4rem]">
-            {activity.rating}
+  // 카드 클릭 시 액티비티 상세 페이지로 이동
+  const handleCardClick = () => {
+    router.push(`/activities/${activity.id}`);
+  };
+
+  return (
+    <div
+      className={`shadow-experience-card flex h-[24.3rem] w-full cursor-pointer flex-col overflow-hidden rounded-[1.2rem] bg-white transition-transform hover:scale-[1.02] md:h-[42.3rem] md:rounded-[2.6rem] lg:h-[36.6rem] ${className}`}
+      onClick={handleCardClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleCardClick();
+        }
+      }}
+    >
+      {/* 이미지 영역 */}
+      <div className="relative aspect-[3/4] w-full overflow-hidden md:-mb-[2.6rem] md:aspect-11/10 lg:aspect-[3/4]">
+        <Image
+          src={activity.bannerImageUrl}
+          alt={activity.title}
+          fill
+          className="rounded-t-3xl object-cover md:rounded-t-[2.6rem]"
+          sizes="(max-width: 768px) 50vw, 25vw"
+          priority={false}
+        />
+      </div>
+
+      {/* 콘텐츠 영역 */}
+      <div className="flex flex-1 flex-col rounded-[1.2rem] px-[1.7rem] py-[1.2rem] md:z-10 md:rounded-t-[2.6rem] md:bg-white md:px-[3rem] md:py-[2rem] lg:px-[2.8rem] lg:py-[2.4rem]">
+        {/* 제목과 별점 그룹 */}
+        <div className="mt-[0.5rem] flex flex-col gap-[0.6rem]">
+          {/* 제목 */}
+          <h3 className="line-clamp-1 text-[1.4rem] leading-[1.8rem] font-semibold text-gray-900 md:overflow-hidden md:text-[1.8rem] md:text-ellipsis md:whitespace-nowrap">
+            {activity.title}
+          </h3>
+          {/* 별점과 리뷰 */}
+          <div className="flex items-center gap-[0.2rem] md:gap-[0.3rem]">
+            <Star className="text-yellow h-[1.25rem] w-[1.25rem] md:h-[2rem] md:w-[2rem]" />
+            <span className="text-[1.2rem] font-medium text-gray-950 md:text-[1.4rem]">
+              {activity.rating}
+            </span>
+            <span className="text-[1.2rem] font-medium text-gray-400 md:text-[1.4rem]">
+              ({activity.reviewCount})
+            </span>
+          </div>
+        </div>
+
+        {/* 가격 */}
+        <div className="mt-[2rem] flex items-baseline gap-1">
+          <span className="text-[1.5rem] leading-[1.8rem] font-bold text-gray-950 md:text-[1.8rem]">
+            ₩ {formatPrice(activity.price)}
           </span>
-          <span className="text-[1.2rem] font-medium text-gray-400 md:text-[1.4rem]">
-            ({activity.reviewCount})
+          <span className="text-[1.2rem] font-semibold text-gray-400 md:text-[1.6rem]">
+            /인
           </span>
         </div>
       </div>
-
-      {/* 가격 */}
-      <div className="mt-[2rem] flex items-baseline gap-1">
-        <span className="text-[1.5rem] leading-[1.8rem] font-bold text-gray-950 md:text-[1.8rem]">
-          ₩ {formatPrice(activity.price)}
-        </span>
-        <span className="text-[1.2rem] font-semibold text-gray-400 md:text-[1.6rem]">
-          /인
-        </span>
-      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/features/activities/components/banner-carousel.tsx
+++ b/src/features/activities/components/banner-carousel.tsx
@@ -4,6 +4,7 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useRef } from 'react';
 import type { Swiper as SwiperType } from 'swiper';
 import { Autoplay, Navigation } from 'swiper/modules';
@@ -20,6 +21,7 @@ import useActivity from '@/shared/libs/hooks/useActivityQuery';
  * @description 배너 캐러셀을 표시하는 컴포넌트입니다.
  */
 const BannerCarousel = () => {
+  const router = useRouter();
   const swiperRef = useRef<SwiperType | null>(null);
   const { data, isLoading, isError } = useActivity({
     sort: 'most_reviewed',
@@ -27,6 +29,11 @@ const BannerCarousel = () => {
     size: 8,
   });
   const banners = data?.activities ?? [];
+
+  // 배너 클릭 시 액티비티 상세 페이지로 이동
+  const handleBannerClick = (activityId: number) => {
+    router.push(`/activities/${activityId}`);
+  };
 
   return (
     <div className="mx-auto mt-[3.2rem] w-full max-w-[112rem] px-[2.4rem] md:mt-[5rem] md:px-[3rem] lg:mt-[7rem] lg:px-[4rem]">
@@ -74,7 +81,18 @@ const BannerCarousel = () => {
         ) : (
           banners.map((banner, idx) => (
             <SwiperSlide key={banner.id}>
-              <div className="relative h-[18.1rem] w-full overflow-hidden rounded-[1.2rem] shadow-lg md:h-[37.5rem] md:rounded-[1.8rem] lg:h-[50rem] lg:rounded-[2.4rem]">
+              <div
+                className="relative h-[18.1rem] w-full cursor-pointer overflow-hidden rounded-[1.2rem] shadow-lg transition-transform hover:scale-[1.02] md:h-[37.5rem] md:rounded-[1.8rem] lg:h-[50rem] lg:rounded-[2.4rem]"
+                onClick={() => handleBannerClick(banner.id)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleBannerClick(banner.id);
+                  }
+                }}
+              >
                 <Image
                   src={banner.bannerImageUrl}
                   alt={banner.title}


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

카톡에 올린 것 처럼 카드, 이미지 선택 시 체험 상세 페이지로 리다이렉트 시켰습니다. 
(영역: 랜딩, 메인화면의 상단 배너, 모든 체험, 인기체험)


## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 활동 카드와 배너 캐러셀에서 클릭 또는 키보드(Enter, Space) 입력 시 활동 상세 페이지로 이동할 수 있도록 인터랙션이 추가되었습니다.

* **접근성 개선**
  * 활동 카드와 배너 캐러셀에 버튼 역할, 탭 이동, 키보드 이벤트 처리가 적용되어 접근성이 향상되었습니다.

* **스타일**
  * 카드와 배너에 커서 포인터 및 호버 시 확대 효과가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->