### PR TITLE
[🐛 Fix] 빌드오류 수정

### DIFF
--- a/src/features/activities/components/search.tsx
+++ b/src/features/activities/components/search.tsx
@@ -8,7 +8,7 @@ import { searchVariant } from '@/shared/libs/constants/searchVariant';
 
 interface SearchProps {
   placeholder?: string;
-  setKeyword: (value: React.SetStateAction<string>) => void;
+  setKeyword?: (value: React.SetStateAction<string>) => void;
 }
 
 const Search: React.FC<SearchProps> = ({


### PR DESCRIPTION
- setKeyword에 ? 추가

<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

<!-- 구현 내용or변경 사항에 대한 간단한 설명 -->
<!-- 관련 이슈는 development로 연결 또는 직접 작성( #issue, closes #issue ) -->

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 검색 컴포넌트의 prop 중 `setKeyword` 콜백이 선택적으로 변경되어, 해당 prop 없이도 컴포넌트 사용이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->