### PR TITLE
[♻️Refactor134] starImage 컴포넌트 적용 (체험 카드)

### DIFF
--- a/src/features/activities/components/activity-card.tsx
+++ b/src/features/activities/components/activity-card.tsx
@@ -1,8 +1,8 @@
-import { Star } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
+import StarImage from '@/shared/components/star';
 import { formatPrice } from '@/shared/libs/utils/formatPrice';
 import { Activity } from '@/shared/types/activity';
 
@@ -63,7 +63,7 @@ export const ActivityCard = ({
           </h3>
           {/* 별점과 리뷰 */}
           <div className="flex items-center gap-[0.2rem] md:gap-[0.3rem]">
-            <Star className="text-yellow h-[1.25rem] w-[1.25rem] md:h-[2rem] md:w-[2rem]" />
+            <StarImage extraClassName="size-[1.3rem] md:size-[2rem]" />
             <span className="text-[1.2rem] font-medium text-gray-950 md:text-[1.4rem]">
               {activity.rating}
             </span>

--- a/src/features/activity-registration/components/activity-registration-form.tsx
+++ b/src/features/activity-registration/components/activity-registration-form.tsx
@@ -74,8 +74,6 @@ const ActivityRegistrationForm = () => {
   const router = useRouter();
 
   const onSubmit = async (data: FormData) => {
-    console.log('폼 제출 시작:', data); // 디버깅용
-
     // 모든 스케줄의 시간 유효성 검증
     const hasInvalidSchedules = data.schedules.some((schedule) => {
       const startIndex = TIME_OPTIONS.findIndex(
@@ -106,12 +104,9 @@ const ActivityRegistrationForm = () => {
       subImageUrls: data.subImages,
     };
 
-    console.log('API 데이터:', apiData); // 디버깅용
-
     // TanStack Query mutation 실행
     try {
       await registrationMutation.mutateAsync(apiData);
-      console.log('등록 성공!'); // 디버깅용
       toast.success('체험이 등록되었습니다!');
       router.push('/activities');
     } catch (error) {

--- a/src/features/activity-registration/libs/hooks/useRegistrationMutation.ts
+++ b/src/features/activity-registration/libs/hooks/useRegistrationMutation.ts
@@ -12,7 +12,7 @@ export const useRegistrationMutation = () => {
     onSuccess: () => {
       // 성공 시 관련 쿼리들을 무효화하여 새로고침
       queryClient.invalidateQueries({ queryKey: ['activities'] });
-      queryClient.invalidateQueries({ queryKey: ['my-activities'] });
+      queryClient.invalidateQueries({ queryKey: ['myActivities'] });
       // toast 메시지 제거 - 모달로 대체
     },
     onError: (error) => {


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

#134 

적용 화면 : activity-card를 사용하는 영역 (메인화면, 랜딩페이지) 에서  lucide-react(star)에서 starImage 컴포넌트로 변경

반응형 대응 완료

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<img width="1343" height="534" alt="image" src="https://github.com/user-attachments/assets/df6478ca-9e86-42d6-81c8-f0795a859b04" />


## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 활동 카드에서 별 아이콘 디자인이 변경되었습니다.

* **Chores**
  * 활동 등록 폼에서 불필요한 콘솔 로그가 제거되었습니다.
  * 활동 등록 후 캐시 무효화 키가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->