### PR TITLE
[✨ 🎨 Feat] 마이페이지 - 내 체험 수정 구현  

### DIFF
--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -21,6 +21,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const isMyPageRoot = pathname === '/my';
   const isActivityRegistration =
     pathname === '/my/my-activities/activity-registration';
+  const isActivityEdit = pathname.startsWith('/my/my-activities/activity-edit');
 
   const handleBackClick = () => {
     router.back();
@@ -48,7 +49,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
       <aside
         className={
-          (isMobile && !isMyPageRoot) || isActivityRegistration ? 'hidden' : ''
+          (isMobile && !isMyPageRoot) ||
+          isActivityRegistration ||
+          isActivityEdit
+            ? 'hidden'
+            : ''
         }
       >
         <Sidebar />

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -1,9 +1,10 @@
 'use client';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Sidebar from '@/features/my/components/sidebar';
+import LoadingSpinner from '@/shared/components/loading-spinner/loading-spinner';
 import useWindowSize from '@/shared/libs/hooks/useWindowSize';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -22,10 +23,23 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const isActivityRegistration =
     pathname === '/my/my-activities/activity-registration';
   const isActivityEdit = pathname.startsWith('/my/my-activities/activity-edit');
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   const handleBackClick = () => {
     router.back();
   };
+
+  if (!isClient) {
+    return (
+      <div className="flex-center h-screen w-full">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/app/my/my-activities/activity-edit/[id]/page.tsx
+++ b/src/app/my/my-activities/activity-edit/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { ParamValue } from 'next/dist/server/request/params';
+
+import ActivityEditForm from '@/features/my/activity-edit/components/activity-edit-form';
+
+const ActivityEditPage = ({ params }: { params: { id: ParamValue } }) => {
+  const activityId = params.id;
+  return (
+    <main>
+      <div className="my-[1rem] flex w-full gap-[0.4rem]">
+        <span className="text-[1.8rem] font-bold text-gray-950">
+          내 체험 등록
+        </span>
+      </div>
+      <ActivityEditForm activityId={activityId} />
+    </main>
+  );
+};
+
+export default ActivityEditPage;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      localStorage.removeItem('auth-storage');
+    }
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/features/my/activity-edit/components/activity-edit-form.tsx
+++ b/src/features/my/activity-edit/components/activity-edit-form.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ParamValue } from 'next/dist/server/request/params';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import z from 'zod';
+
+import BannerImageUpload from '@/features/activity-registration/components/banner-image-upload';
+import DateScheduler from '@/features/activity-registration/components/date-scheduler';
+import SubImage from '@/features/activity-registration/components/sub-image';
+import {
+  CATEGORY_OPTIONS,
+  FORM_CONSTRAINTS,
+  TIME_OPTIONS,
+} from '@/features/activity-registration/libs/constants/formOption';
+import { useRegistrationMutation } from '@/features/activity-registration/libs/hooks/useRegistrationMutation';
+import { getActivityId } from '@/features/activityId/libs/api/getActivityId';
+import { FormInput } from '@/shared/components/form-input/form-input';
+
+// 기존 hasDuplicateStartTime 함수를 사용
+
+const registerSchema = z.object({
+  title: z.string().min(1, { message: '제목을 입력해 주세요.' }),
+  category: z.string().min(1, { message: '카테고리를 선택해 주세요.' }),
+  address: z.string().min(1, { message: '주소를 입력해주세요.' }),
+  description: z.string().min(1, { message: '설명을 입력해 주세요.' }),
+  price: z
+    .number()
+    .min(FORM_CONSTRAINTS.PRICE.MIN, {
+      message: `최소 ${FORM_CONSTRAINTS.PRICE.MIN}원 이상 입력해 주세요.`,
+    })
+    .max(FORM_CONSTRAINTS.PRICE.MAX, {
+      message: `최대 ${FORM_CONSTRAINTS.PRICE.MAX.toLocaleString()}원 이하 입력해 주세요.`,
+    }),
+  schedules: z
+    .array(
+      z.object({
+        date: z.string().min(1, {
+          message: '날짜를 선택해 주세요.',
+        }),
+        startTime: z.string().min(1, { message: '시작 시간을 선택해 주세요.' }),
+        endTime: z.string().min(1, { message: '종료 시간을 선택해 주세요.' }),
+      }),
+    )
+    .min(1, { message: '예약 가능한 시간대는 최소 1개 이상 등록해주세요.' }),
+  bannerImages: z.string().min(1, { message: '배너 이미지를 등록해 주세요.' }),
+  subImages: z
+    .array(z.string())
+    .min(1, { message: '소개 이미지를 등록해 주세요.' }),
+});
+
+type FormData = z.infer<typeof registerSchema>;
+
+interface ActivityEditFormProps {
+  activityId: ParamValue;
+}
+
+const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    trigger,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(registerSchema),
+    mode: 'onChange',
+  });
+
+  const registrationMutation = useRegistrationMutation();
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchActivityData = async () => {
+      try {
+        const data = await getActivityId(activityId);
+        if (data) {
+          reset({
+            title: data.title,
+            category: data.category,
+            description: data.description,
+            address: data.address,
+            price: String(data.price), // formInput 수정 필요해보임
+            bannerImages: data.bannerImageUrl,
+            subImages: data.subImages.map((img) => img.imageUrl),
+            schedules: data.schedules.map((schedule) => ({
+              date: schedule.date,
+              startTime: schedule.startTime,
+              endTime: schedule.endTime,
+            })),
+          });
+        } else {
+          toast.error('체험 정보를 불러오지 못했습니다.');
+          router.push('/my/my-activities');
+        }
+      } catch {
+        toast.error('오류기 발생했습니다.');
+        console.error('오류 발생'); // 디버깅용
+      }
+    };
+    fetchActivityData();
+  }, [activityId, reset, router]);
+
+  const onSubmit = async (data: FormData) => {
+    // 모든 스케줄의 시간 유효성 검증
+    const hasInvalidSchedules = data.schedules.some((schedule) => {
+      const startIndex = TIME_OPTIONS.findIndex(
+        (option) => option.value === schedule.startTime,
+      );
+      const endIndex = TIME_OPTIONS.findIndex(
+        (option) => option.value === schedule.endTime,
+      );
+      return endIndex <= startIndex;
+    });
+
+    if (hasInvalidSchedules) {
+      alert('시간 설정을 확인해 주세요.');
+      return;
+    }
+
+    // TanStack Query mutation 실행
+    //     try {
+    //       await registrationMutation.mutateAsync(apiData);
+    //       console.log('등록 성공!'); // 디버깅용
+    //       toast.success('체험이 등록되었습니다!');
+    //       router.push('/activities');
+    //     } catch (error) {
+    //       console.error('등록 실패:', error); // 디버깅용
+    //       toast.error('등록 중 오류가 발생했습니다. 다시 시도해주세요.');
+    //     }
+    //   };
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="mt-[2.4rem] flex flex-col"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {
+          const target = e.target as HTMLInputElement;
+          if (target.type === 'button' || target.readOnly) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }
+      }}
+    >
+      {/* 제목 */}
+      <FormInput
+        label="제목"
+        name="title"
+        register={register}
+        error={errors.title}
+        inputType="input"
+        placeholder="제목을 입력해 주세요"
+        required
+      />
+
+      {/* 카테고리 */}
+      <FormInput
+        label="카테고리"
+        name="category"
+        register={register}
+        error={errors.category}
+        inputType="select"
+        options={CATEGORY_OPTIONS}
+        placeholder="카테고리를 선택해 주세요"
+        required
+      />
+
+      {/* 설명 */}
+      <FormInput
+        label="설명"
+        name="description"
+        register={register}
+        error={errors.description}
+        inputType="textarea"
+        rows={6}
+        placeholder="체험에 대한 설명을 입력해 주세요"
+        required
+      />
+
+      {/* 가격 */}
+      <FormInput
+        label="가격"
+        name="price"
+        register={register}
+        error={errors.price}
+        inputType="number"
+        placeholder="체험 금액을 입력해 주세요"
+        required
+      />
+
+      {/* 주소 */}
+      <FormInput
+        label="주소"
+        name="address"
+        register={register}
+        setValue={setValue}
+        watch={watch}
+        error={errors.address}
+        inputType="address"
+        placeholder="주소를 입력해 주세요"
+        required
+      />
+
+      {/* DateScheduler 컴포넌트 사용 */}
+      <DateScheduler
+        schedules={watch('schedules') || []}
+        onChange={async (schedules) => {
+          setValue('schedules', schedules);
+          await trigger('schedules');
+        }}
+        errors={{ schedules: errors.schedules }}
+        register={register}
+        formErrors={errors}
+      />
+
+      <BannerImageUpload
+        label="배너 이미지 등록"
+        name="bannerImages"
+        error={errors.bannerImages}
+        required
+        onChange={async (imageUrl: string) => {
+          setValue('bannerImages', imageUrl);
+          await trigger('bannerImages');
+        }}
+        value={watch('bannerImages') || ''}
+      />
+
+      <SubImage
+        label="소개 이미지 등록"
+        name="subImages"
+        error={errors.subImages}
+        onChange={async (imageUrls: string[]) => {
+          setValue('subImages', imageUrls);
+          await trigger('subImages');
+        }}
+        value={watch('subImages') || []}
+      />
+
+      {/* 제출 버튼 */}
+      <div className="flex-center">
+        <button
+          type="submit"
+          disabled={registrationMutation.isPending}
+          className={`h-[4.1rem] w-[16rem] cursor-pointer rounded-[1.2rem] text-center text-[1.4rem] font-bold text-white md:h-[4.8rem] md:w-[16rem] md:rounded-[1.6rem] md:text-[1.6rem] lg:h-[5.2rem] lg:w-[18rem] ${
+            registrationMutation.isPending
+              ? 'cursor-not-allowed bg-gray-400'
+              : 'bg-main hover:bg-blue-500'
+          }`}
+        >
+          {registrationMutation.isPending ? '등록 중...' : '체험 등록하기'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ActivityEditForm;

--- a/src/features/my/activity-edit/components/activity-edit-form.tsx
+++ b/src/features/my/activity-edit/components/activity-edit-form.tsx
@@ -60,7 +60,7 @@ type FormData = z.infer<typeof registerSchema>;
 interface ActivityEditFormProps {
   activityId: ParamValue;
 }
-
+// activityId: ParamValue 를 받음 (동적 이동)
 const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
   const {
     register,
@@ -80,6 +80,7 @@ const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
   const [initialActivityData, setInitialActivityData] =
     useState<ActivityInfo | null>(null);
 
+  // activityId를 기반으로
   useEffect(() => {
     const fetchActivityData = async () => {
       try {
@@ -130,6 +131,11 @@ const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
       return;
     }
 
+    if (!initialActivityData) {
+      toast.error('기존 체험 데이터를 불러오지 못했습니다.');
+      return;
+    }
+
     // 스케줄 처리 : 추가, 삭제 id 찾기
     const schedulesToAdd = data.schedules
       .filter((schedule) => !schedule.id)
@@ -140,7 +146,7 @@ const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
         .filter((schedule) => schedule.id)
         .map((schedule) => schedule.id),
     );
-    const scheduleIdsToRemove = initialActivityData?.schedules
+    const scheduleIdsToRemove = initialActivityData.schedules
       .filter((schedule) => !currentScheduleIds.has(schedule.id))
       .map((schedule) => schedule.id);
 
@@ -152,7 +158,7 @@ const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
     const subImageUrlsToAdd = data.subImages.filter(
       (url) => !initialSubImageUrls.has(url),
     );
-    const subImageIdsToRemove = initialActivityData?.subImages
+    const subImageIdsToRemove = initialActivityData.subImages
       .filter((img) => !currentImageUrls.has(img.imageUrl))
       .map((img) => img.id);
 
@@ -165,7 +171,7 @@ const ActivityEditForm = ({ activityId }: ActivityEditFormProps) => {
       address: data.address,
       bannerImageUrl: data.bannerImages,
       schedulesToAdd,
-      scheduleIdsToRemove,
+      schedulesToRemove: scheduleIdsToRemove,
       subImageUrlsToAdd,
       subImageIdsToRemove,
     };

--- a/src/features/my/activity-edit/libs/api/activity-edit.api.ts
+++ b/src/features/my/activity-edit/libs/api/activity-edit.api.ts
@@ -1,0 +1,11 @@
+import { EditActivityRequest } from '@/features/my/activity-edit/libs/types/types';
+import { EditActivityResponse } from '@/features/my/activity-edit/libs/types/types';
+import api from '@/shared/libs/api/axios';
+
+export const editActivity = async (
+  id: number,
+  data: EditActivityRequest,
+): Promise<EditActivityResponse> => {
+  const response = await api.patch(`/my-activities/${id}`, data);
+  return response.data;
+};

--- a/src/features/my/activity-edit/libs/hooks/useEditActivityMutation.ts
+++ b/src/features/my/activity-edit/libs/hooks/useEditActivityMutation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { editActivity } from '@/features/my/activity-edit/libs/api/activity-edit.api';
+import { EditActivityRequest } from '@/features/my/activity-edit/libs/types/types';
+
+interface EditActivityParams {
+  id: number;
+  payload: EditActivityRequest;
+}
+
+export const useEditActivityMutation = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: ({ id, payload }: EditActivityParams) =>
+      editActivity(id, payload),
+    onSuccess: () => {
+      toast.success('체험 수정이 완료되었습니다.');
+      router.push('/my/my-activities');
+    },
+    onError: (error) => {
+      console.error('체험 수정 실패:', error);
+      toast.error('체험 수정에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/features/my/activity-edit/libs/types/types.ts
+++ b/src/features/my/activity-edit/libs/types/types.ts
@@ -1,0 +1,41 @@
+export interface CreateSheduleBody {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+export interface SubImage {
+  id: number;
+  url: string;
+}
+
+export interface schedules extends CreateSheduleBody {
+  id: number;
+}
+
+export interface EditActivityRequest {
+  title: string;
+  category: string;
+  description: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  subImageUrlsToAdd: string[];
+  schedulesToRemove: number[];
+  schedulesToAdd: CreateSheduleBody[];
+}
+
+export interface EditActivityResponse {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  subImages: SubImage[];
+  schedules: schedules[];
+}

--- a/src/features/my/my-activities/components/my-activities-card.tsx
+++ b/src/features/my/my-activities/components/my-activities-card.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import { useModalStore } from '@/shared/libs/stores/useModalStore';
 import { formatPrice } from '@/shared/libs/utils/formatPrice';
@@ -6,8 +7,15 @@ import { formatPrice } from '@/shared/libs/utils/formatPrice';
 import { MyActivitiesCardProps } from '../lib/types/types';
 const MyActivitiesCard = ({ activity }: MyActivitiesCardProps) => {
   const { openModal } = useModalStore();
+  const router = useRouter();
+
   const handleDelete = () => {
+    console.log(typeof activity.id);
     openModal(activity.id);
+  };
+
+  const hadnleEdit = () => {
+    router.push(`/my/my-activities/activity-edit/${activity.id}`);
   };
   return (
     <article className="shadow-experience-card mb-[3rem] flex justify-between rounded-[2.4rem] bg-white p-[2.4rem] lg:mb-[2.4rem] lg:items-center lg:p-[3rem]">
@@ -43,7 +51,10 @@ const MyActivitiesCard = ({ activity }: MyActivitiesCardProps) => {
           </div>
         </div>
         <div className="flex gap-[0.8rem]">
-          <button className="h-[2.9rem] w-[6.8rem] cursor-pointer rounded-[0.8rem] border border-gray-50 text-[1.4rem] font-medium text-gray-600 transition-colors hover:bg-gray-200 hover:text-white">
+          <button
+            className="h-[2.9rem] w-[6.8rem] cursor-pointer rounded-[0.8rem] border border-gray-50 text-[1.4rem] font-medium text-gray-600 transition-colors hover:bg-gray-200 hover:text-white"
+            onClick={hadnleEdit}
+          >
             수정하기
           </button>
           <button


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

<!-- 구현 내용or변경 사항에 대한 간단한 설명 -->
<!-- 관련 이슈는 development로 연결 또는 직접 작성( #issue, closes #issue ) -->

내 체험관리 수정 구현하였습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 내 체험 활동을 수정할 수 있는 활동 수정 페이지가 추가되었습니다.
  * 활동 카드에서 "수정하기" 버튼을 클릭하면 해당 활동의 수정 페이지로 이동할 수 있습니다.
  * 활동 수정 폼에서 제목, 카테고리, 주소, 설명, 가격, 일정, 이미지 등을 편집할 수 있습니다.

* **버그 수정**
  * 활동 수정 페이지 및 특정 경로에서 모바일 화면에 사이드바가 표시되지 않도록 개선되었습니다.

* **기타**
  * 활동 수정 시 기존 일정과 이미지의 변경 사항만 반영하여 효율적으로 업데이트합니다.
  * 저장 성공 및 오류 발생 시 사용자에게 알림을 제공합니다.
  * 활동 수정 폼 로딩 중에는 로딩 스피너가 표시됩니다.
  * 개발 환경에서 인증 저장소가 초기화되도록 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->