### PR TITLE
♻️ refactor: 예약 목록 LCP 개선 - 우선순위 이미지 및 캐싱 최적

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
         pathname: '/**',
       },
     ],
+    // 이미지 최적화 설정 강화
+    formats: ['image/webp', 'image/avif'],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    minimumCacheTTL: 60 * 60 * 24 * 30, // 30일 캐시
   },
 };
 

--- a/src/features/activities/components/activity-card.tsx
+++ b/src/features/activities/components/activity-card.tsx
@@ -9,6 +9,7 @@ import { Activity } from '@/shared/types/activity';
 interface ActivityCardProps {
   activity: Activity;
   className?: string;
+  isPriority?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ interface ActivityCardProps {
 export const ActivityCard = ({
   activity,
   className = '',
+  isPriority = false,
 }: ActivityCardProps) => {
   const router = useRouter();
 
@@ -49,7 +51,8 @@ export const ActivityCard = ({
           fill
           className="rounded-t-[0.8rem] object-cover md:rounded-t-[1.8rem]"
           sizes="(max-width: 768px) 50vw, 25vw"
-          priority={false}
+          priority={isPriority}
+          quality={75}
         />
       </div>
 

--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -130,8 +130,12 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
           ) : isError ? (
             <ErrorMessage className="col-span-2 lg:col-span-4" />
           ) : (
-            activities.map((activity) => (
-              <ActivityCard key={activity.id} activity={activity} />
+            activities.map((activity, index) => (
+              <ActivityCard
+                key={activity.id}
+                activity={activity}
+                isPriority={index < 8}
+              />
             ))
           )}
         </div>

--- a/src/features/activities/components/banner-carousel.tsx
+++ b/src/features/activities/components/banner-carousel.tsx
@@ -99,6 +99,7 @@ const BannerCarousel = () => {
                   fill
                   className="object-cover"
                   priority={idx === 0}
+                  quality={idx === 0 ? 85 : 75}
                   sizes="(max-width: 768px) 100vw, (max-width: 1024px) 100vw, 112rem"
                 />
                 <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/90 to-transparent p-2 transition-opacity duration-700 md:p-8 lg:p-12">

--- a/src/features/activities/components/best-activities.tsx
+++ b/src/features/activities/components/best-activities.tsx
@@ -102,11 +102,12 @@ const BestActivities = () => {
             }}
             className="best-activities !overflow-visible !px-0"
           >
-            {activities.map((activity) => (
+            {activities.map((activity, index) => (
               <SwiperSlide key={activity.id}>
                 <ActivityCard
                   activity={activity}
                   className="mb-[2.4rem] md:mb-[8rem]"
+                  isPriority={index < 4}
                 />
               </SwiperSlide>
             ))}

--- a/src/features/activities/components/search-result.tsx
+++ b/src/features/activities/components/search-result.tsx
@@ -45,8 +45,12 @@ const SearchResults = ({ keyword }: SearchResultProps) => {
           {activities.length > 0 ? (
             <>
               <div className="grid grid-cols-2 gap-x-[1.8rem] gap-y-[2.4rem] md:gap-x-6 md:gap-y-[2.4rem] lg:grid-cols-4 lg:gap-x-[3rem] lg:gap-y-[2.4rem]">
-                {activities.map((activity) => (
-                  <ActivityCard key={activity.id} activity={activity} />
+                {activities.map((activity, index) => (
+                  <ActivityCard
+                    key={activity.id}
+                    activity={activity}
+                    isPriority={index < 8}
+                  />
                 ))}
               </div>
               <Pagination

--- a/src/features/booking-detail/components/booking-card-container.tsx
+++ b/src/features/booking-detail/components/booking-card-container.tsx
@@ -9,6 +9,7 @@ interface BookingCardContainerProps {
   reservation: Reservation;
   showDate?: boolean;
   showDivider?: boolean;
+  isPriority?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ const BookingCardContainer = ({
   reservation,
   showDate = true,
   showDivider = true,
+  isPriority = false,
 }: BookingCardContainerProps) => {
   const { isModalOpen, activeReservationId, openModal, closeModal } =
     useModalStore();
@@ -50,6 +52,7 @@ const BookingCardContainer = ({
       onCancelClick={handleCancelClick}
       onReviewClick={handleReviewClick}
       onModalClose={closeModal}
+      isPriority={isPriority}
     />
   );
 };

--- a/src/features/booking-detail/components/booking-card.tsx
+++ b/src/features/booking-detail/components/booking-card.tsx
@@ -2,6 +2,10 @@ import Image from 'next/image';
 import React from 'react';
 
 import { formatPrice } from '@/shared/libs/utils/formatPrice';
+import {
+  generateResponsiveSizes,
+  optimizeImageQuality,
+} from '@/shared/libs/utils/imageOptimization';
 
 import { Reservation } from '../libs/types/booking';
 import {
@@ -20,6 +24,7 @@ interface BookingCardProps {
   onCancelClick?: () => void;
   onReviewClick?: () => void;
   onModalClose?: () => void;
+  isPriority?: boolean;
 }
 
 /**
@@ -42,6 +47,7 @@ const BookingCard = ({
   onCancelClick,
   onReviewClick,
   onModalClose,
+  isPriority = false,
 }: BookingCardProps) => {
   const statusLabel = getStatusLabel(reservation.status);
   const statusColorClass = getStatusColorClass(reservation.status);
@@ -63,9 +69,15 @@ const BookingCard = ({
             src={reservation.activity.bannerImageUrl}
             alt={reservation.activity.title}
             fill
-            quality={90}
-            loading="lazy"
+            quality={optimizeImageQuality(isPriority)}
+            priority={isPriority}
+            loading={isPriority ? undefined : 'lazy'}
             className="size-[13.6rem] object-cover md:size-[14rem] lg:size-[18.1rem]"
+            sizes={generateResponsiveSizes({
+              mobile: '100vw',
+              tablet: '50vw',
+              desktop: '25vw',
+            })}
           />
         </div>
 

--- a/src/features/booking-detail/components/booking-list.tsx
+++ b/src/features/booking-detail/components/booking-list.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from '@/shared/components/loading-spinner/loading-spinner'
 import { sortDatesAscending } from '@/shared/libs/utils/parseDate';
 
 import { useBookingQuery } from '../libs/hooks/useBookingQuery';
+import { GetBookingResponse } from '../libs/types/booking';
 import FilterButtons from './filter-buttons';
 import GroupedBookingCards from './group-booking-card';
 
@@ -18,7 +19,11 @@ import GroupedBookingCards from './group-booking-card';
  * @author 김영현
  */
 const BookingList = () => {
-  const { data, isLoading, isError } = useBookingQuery();
+  const { data, isLoading, isError } = useBookingQuery() as {
+    data: GetBookingResponse | undefined;
+    isLoading: boolean;
+    isError: boolean;
+  };
   const [activeStatus, setActiveStatus] = useState('');
 
   // 날짜 기준 오름차순 정렬

--- a/src/features/booking-detail/components/group-booking-card.tsx
+++ b/src/features/booking-detail/components/group-booking-card.tsx
@@ -32,7 +32,7 @@ const GroupedBookingCards = ({ reservations }: GroupedBookingsProps) => {
 
   return (
     <div className="flex flex-col gap-[2rem]">
-      {sortedDates.map((date) => (
+      {sortedDates.map((date, dateIndex) => (
         <div key={date} className="flex flex-col gap-[1.2rem]">
           {/* 날짜 헤더 - 한 번만 표시 */}
           <div className="text-[1.6rem] font-bold text-gray-800 md:text-[1.8rem]">
@@ -47,6 +47,7 @@ const GroupedBookingCards = ({ reservations }: GroupedBookingsProps) => {
                 reservation={reservation}
                 showDate={false} // 그룹 내에서는 날짜를 표시하지 않음
                 showDivider={index === groupedReservations[date].length - 1}
+                isPriority={dateIndex === 0 && index === 0} // 첫 번째 날짜의 첫 번째 카드만 우선순위
               />
             ))}
           </div>

--- a/src/features/booking-detail/libs/hooks/useBookingQuery.ts
+++ b/src/features/booking-detail/libs/hooks/useBookingQuery.ts
@@ -7,7 +7,8 @@ export const useBookingQuery = (params?: GetBookingParams) => {
   return useQuery<GetBookingResponse>({
     queryKey: ['booking', params],
     queryFn: () => getBooking(params),
-    staleTime: 1000 * 60 * 30,
+    staleTime: 1000 * 60 * 60 * 2, // 2시간
+    cacheTime: 1000 * 60 * 60 * 24, // 24시간
     retry: 1,
   });
 };

--- a/src/shared/libs/utils/imageOptimization.ts
+++ b/src/shared/libs/utils/imageOptimization.ts
@@ -1,0 +1,49 @@
+/**
+ * 이미지 최적화 유틸리티
+ * @description LCP 시간 단축을 위한 이미지 최적화 도구들
+ */
+
+/**
+ * 이미지 우선순위 결정 함수
+ * @param index - 이미지 인덱스
+ * @param maxPriority - 최대 우선순위 이미지 수 (기본값: 4)
+ * @returns 우선순위 여부
+ */
+export const shouldPrioritizeImage = (
+  index: number,
+  maxPriority: number = 4,
+): boolean => {
+  return index < maxPriority;
+};
+
+/**
+ * 이미지 품질 최적화
+ * @param isPriority - 우선순위 이미지 여부
+ * @param baseQuality - 기본 품질 (기본값: 75)
+ * @param priorityQuality - 우선순위 이미지 품질 (기본값: 85)
+ * @returns 최적화된 품질 값
+ */
+export const optimizeImageQuality = (
+  isPriority: boolean,
+  baseQuality: number = 75,
+  priorityQuality: number = 85,
+): number => {
+  return isPriority ? priorityQuality : baseQuality;
+};
+
+/**
+ * 반응형 sizes 속성 생성
+ * @param breakpoints - 브레이크포인트 설정
+ * @returns sizes 문자열
+ */
+export const generateResponsiveSizes = (
+  breakpoints: {
+    mobile?: string;
+    tablet?: string;
+    desktop?: string;
+  } = {},
+): string => {
+  const { mobile = '100vw', tablet = '50vw', desktop = '25vw' } = breakpoints;
+
+  return `(max-width: 768px) ${mobile}, (max-width: 1024px) ${tablet}, ${desktop}`;
+};


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

어제 부터 진행한 이미지 로드 개선 최적화 관련 코드 입니다. 

기본적으로 캐싱 전략 추가와 기본 품질을 75로 세팅하고(기존 90), 첫번째 이미지만(배너 이미지경우) 85를 줬습니다.
추가로 첫 이미지 로드시 인기 체험은 4개, 모든 체험은 8개를 불러오게 했습니다.

재방문 시 더 빠르게 로드될 수 있도록 수정했습니다. 

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이미지 우선순위 및 품질 최적화 유틸리티가 추가되어, 주요 이미지의 로딩 속도와 품질이 개선되었습니다.
  * ActivityCard, BookingCard 등 주요 카드 컴포넌트에 이미지 우선순위 및 품질 설정 기능이 도입되었습니다.

* **개선 사항**
  * 이미지 최적화 설정이 세분화되어 다양한 포맷(WebP, AVIF)과 디바이스별 크기, 캐시 기간이 명확히 지정되었습니다.
  * 예약 관련 데이터의 캐시 유지 시간이 연장되어, 더 빠른 화면 전환이 가능합니다.

* **버그 수정**
  * 일부 컴포넌트의 이미지 품질 및 로딩 방식이 상황에 따라 유동적으로 적용되어, 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->