### PR TITLE
[🐛Fix] QA(8/29) 반영

### DIFF
--- a/src/app/my/reserve-calendar/page.tsx
+++ b/src/app/my/reserve-calendar/page.tsx
@@ -128,10 +128,8 @@ const ReserveCalendarPage = () => {
   const handleDropdownOpen = () => setShouldFetch(true);
 
   const handleDateClick = async (dateStr: string) => {
-    if (!selectedActivityId || !accessToken) {
-      setSelectedScheduleId([]);
-      return;
-    }
+    setSelectedScheduleId([]);
+    if (!selectedActivityId || !accessToken) return;
 
     try {
       const dayReservations: Reservation[] = await getReservations({

--- a/src/features/activities/components/all-activities.tsx
+++ b/src/features/activities/components/all-activities.tsx
@@ -84,23 +84,28 @@ const AllActivities = ({ keyword }: AllActivitiesProps) => {
           }
           dropdownClassName="absolute right-0"
         >
-          <div className="border-sub-300 txt-14-medium h-[12.3rem] w-[9.6rem] overflow-hidden rounded-xl border-[0.1rem] bg-white">
-            {SORT_OPTIONS.map(({ label, value }) => (
-              <button
-                key={value}
-                onClick={() =>
-                  handleSortChange(
-                    value as 'latest' | 'price_asc' | 'price_desc',
-                  )
-                }
-                className={`txt-14-medium h-[4.1rem] w-full cursor-pointer px-[1rem] py-[0.6rem] hover:bg-blue-50 ${
-                  selectedSort === value ? 'text-main font-bold' : 'text-black'
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
+          {(close) => (
+            <div className="border-sub-300 txt-14-medium h-[12.3rem] w-[9.6rem] overflow-hidden rounded-xl border-[0.1rem] bg-white">
+              {SORT_OPTIONS.map(({ label, value }) => (
+                <button
+                  key={value}
+                  onClick={() => {
+                    handleSortChange(
+                      value as 'latest' | 'price_asc' | 'price_desc',
+                    );
+                    close();
+                  }}
+                  className={`txt-14-medium h-[4.1rem] w-full cursor-pointer px-[1rem] py-[0.6rem] hover:bg-blue-50 ${
+                    selectedSort === value
+                      ? 'text-main font-bold'
+                      : 'text-black'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
         </Dropdown>
       </div>
 

--- a/src/features/activities/components/search.tsx
+++ b/src/features/activities/components/search.tsx
@@ -5,40 +5,27 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 import { getActListApi } from '@/features/activities/libs/api/getActListApi';
+import { useSearchStore } from '@/features/activities/libs/stores/searchStore';
 import Dropdown from '@/shared/components/dropdown/dropdown';
 import { Button } from '@/shared/components/modal/components/modal-button';
 import { searchVariant } from '@/shared/libs/constants/searchVariant';
 
 interface SearchProps {
   placeholder?: string;
-  setKeyword?: (value: React.SetStateAction<string>) => void;
 }
 
 const Search: React.FC<SearchProps> = ({
   placeholder = '내가 원하는 체험은',
-  setKeyword: externalSetKeyword,
 }) => {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const defaultValue = searchParams.get('keyword') ?? '';
-  const defaultRegion = searchParams.get('region') ?? '';
-  const defaultCategory = searchParams.get('category') ?? '';
+  const { keyword, setKeyword, region, setRegion, category, setCategory } =
+    useSearchStore();
 
-  // 상태
-  const [keyword, setKeyword] = useState(defaultValue);
-  const [region, setRegion] = useState(defaultRegion);
-  const [category, setCategory] = useState(defaultCategory);
   const [isFocused, setIsFocused] = useState(false);
-
   const [regionOptions, setRegionOptions] = useState<string[]>([]);
   const [categoryOptions, setCategoryOptions] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (externalSetKeyword) {
-      externalSetKeyword(keyword);
-    }
-  }, [keyword, externalSetKeyword]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/features/activities/components/search.tsx
+++ b/src/features/activities/components/search.tsx
@@ -85,13 +85,13 @@ const Search: React.FC<SearchProps> = ({
   const style = searchVariant.main;
 
   const dropdownBtnClass =
-    'flex w-[20rem] items-center justify-between rounded txt-14-medium text-gray-700 bg-transparent hover:bg-gray-50';
+    'flex w-[20rem] items-center justify-between rounded txt-14-medium text-gray-700 bg-transparent hover:bg-gray-50 cursor-pointer';
 
   const dropdownMenuClass =
     'mt-1 w-full bg-white rounded shadow-md txt-14-medium';
 
   const optionBtnClass =
-    'w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-blue-50';
+    'w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-blue-50 cursor-pointer';
 
   return (
     <div className={style.wrapper}>

--- a/src/features/activities/components/search.tsx
+++ b/src/features/activities/components/search.tsx
@@ -120,16 +120,21 @@ const Search: React.FC<SearchProps> = ({
             }
             dropdownClassName={dropdownMenuClass}
           >
-            {regionOptions.map((option) => (
-              <button
-                key={option}
-                type="button"
-                className={optionBtnClass}
-                onClick={() => setRegion(option)}
-              >
-                {option}
-              </button>
-            ))}
+            {(close) =>
+              regionOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={optionBtnClass}
+                  onClick={() => {
+                    setRegion(option);
+                    close();
+                  }}
+                >
+                  {option}
+                </button>
+              ))
+            }
           </Dropdown>
           {region && (
             <button
@@ -154,16 +159,21 @@ const Search: React.FC<SearchProps> = ({
             }
             dropdownClassName={dropdownMenuClass}
           >
-            {categoryOptions.map((option) => (
-              <button
-                key={option}
-                type="button"
-                className={optionBtnClass}
-                onClick={() => setCategory(option)}
-              >
-                {option}
-              </button>
-            ))}
+            {(close) =>
+              categoryOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={optionBtnClass}
+                  onClick={() => {
+                    setCategory(option);
+                    close();
+                  }}
+                >
+                  {option}
+                </button>
+              ))
+            }
           </Dropdown>
           {category && (
             <button

--- a/src/features/activities/libs/stores/searchStore.ts
+++ b/src/features/activities/libs/stores/searchStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  keyword: string;
+  region: string;
+  category: string;
+  setKeyword: (value: string) => void;
+  setRegion: (value: string) => void;
+  setCategory: (value: string) => void;
+  reset: () => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  keyword: '',
+  region: '',
+  category: '',
+  setKeyword: (value) => set({ keyword: value }),
+  setRegion: (value) => set({ region: value }),
+  setCategory: (value) => set({ category: value }),
+  reset: () => set({ keyword: '', region: '', category: '' }),
+}));

--- a/src/features/reservation-state/components/content-reservation.tsx
+++ b/src/features/reservation-state/components/content-reservation.tsx
@@ -11,6 +11,7 @@ export type DisplayReservation = {
   status: 'pending' | 'confirmed' | 'declined';
   startTime: string;
   endTime: string;
+  date: string;
 };
 
 interface ContentReservationProps {
@@ -65,15 +66,21 @@ export const ContentReservation: React.FC<ContentReservationProps> = ({
                   'pending',
                 startTime: r.startTime,
                 endTime: r.endTime,
+                date: r.date,
               })),
             ),
         );
-        setReservations(allReservations);
 
-        // 모든 시간대 목록
+        const onlySelectedDate = allReservations.filter(
+          (r) => r.date.split('T')[0] === selectedDate,
+        );
+
+        setReservations(onlySelectedDate);
+
+        // 시간 슬롯 리스트 생성
         const slots = [
           ...new Set(
-            allReservations.map((r) => `${r.startTime} - ${r.endTime}`),
+            onlySelectedDate.map((r) => `${r.startTime} - ${r.endTime}`),
           ),
         ];
         setSelectedTimeSlot((prev) => prev ?? slots[0] ?? null);
@@ -194,16 +201,16 @@ export const ContentReservation: React.FC<ContentReservationProps> = ({
       </div>
 
       <div className="mb-6">
-        <div className="txt-14-bold mb-1 block">예약 시간</div>
+        <div className="txt-14-bold mb-1">예약 시간</div>
         <div className="relative">
           <select
             className="txt-14-medium h-[4.4rem] w-full appearance-none rounded-2xl border p-4 pr-10"
             value={selectedTimeSlot ?? ''}
             onChange={(e) => setSelectedTimeSlot(e.target.value || null)}
           >
-            {timeSlots.map((timeSlot) => (
-              <option key={timeSlot} value={timeSlot}>
-                {timeSlot}
+            {timeSlots.map((slot) => (
+              <option key={slot} value={slot}>
+                {slot}
               </option>
             ))}
           </select>

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -30,7 +30,7 @@ const Header = () => {
   const { openModal, closeModal, modalName } = useModalStore();
   const resetSearch = useSearchStore((state) => state.reset);
 
-  if (!hydrated) return null;
+  if (!hydrated) return <div className="h-[4.8rem] md:h-[6rem]"></div>;
 
   const handleLogoutConfirm = () => {
     queryClient.clear();

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import React from 'react';
 
 import NotificationButton from '@/features/activities/components/notification-button';
+import { useSearchStore } from '@/features/activities/libs/stores/searchStore';
 import { useSavePathActivityId } from '@/features/activityId/libs/hooks/useSavePathActivityId';
 import { useAuthStore } from '@/features/auth/stores/useAuthStore';
 import { useRedirectAfterSuccess } from '@/features/auth/utils/hooks/useRedirectAfterSuccess';
@@ -27,6 +28,7 @@ const Header = () => {
   const redirectAfterLogout = useRedirectAfterSuccess();
   const savePathActivityId = useSavePathActivityId();
   const { openModal, closeModal, modalName } = useModalStore();
+  const resetSearch = useSearchStore((state) => state.reset);
 
   if (!hydrated) return null;
 
@@ -42,7 +44,15 @@ const Header = () => {
     <>
       <nav className="bg-sub mx-auto flex h-[4.8rem] w-full items-center justify-between px-[2.4rem] py-[0.6rem] md:h-[6rem] md:px-[3rem] md:py-[1rem] lg:px-[20rem]">
         <div className="text-main txt-20-bold cursor-pointer md:flex md:gap-3">
-          <Link href="/activities" className="flex items-center gap-3">
+          <Link
+            href="/activities"
+            className="flex items-center gap-3"
+            onClick={(e) => {
+              e.preventDefault();
+              resetSearch();
+              router.push('/activities');
+            }}
+          >
             <Image
               src="/images/icons/logo.svg"
               alt="Logo"

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -119,6 +119,7 @@ const Header = () => {
               {/* 비로그인 상태일 때 */}
               <li>
                 <button
+                  className="cursor-pointer"
                   onClick={() => {
                     savePathActivityId();
                     router.push('/login');
@@ -129,6 +130,7 @@ const Header = () => {
               </li>
               <li>
                 <button
+                  className="cursor-pointer"
                   onClick={() => {
                     savePathActivityId();
                     router.push('/signup');


### PR DESCRIPTION
## ✨ 요약

- QA(8/29) 반영

## 📝 상세 내용

 - 헤더 이미지 클릭 시 검색 조건 초기화
 - 예약 현황(신청/완료한 건 승인/거절 탭) 나오지 않는 현상
 - (헤더 로그인/회원가입/서치 드롭다운) cursor-pointer 적용
 - 드롭다운 선택 시 닫히도록(체험 드롭다운, 서치 드롭다운)
 - 예약 승인,거절 후 my/reservation 페이지 관련 캐시 업데이트 (현재 새로고침 해야 업데이트O)
 - 다른 날짜를 선택하면, 모달에 이전날짜의 예약데이터가 남아 있는 순간이 있는데, selectedDate 변경 시 예약데이터 리셋
 - 여러 시간대의 예약 내역이 다 보이지 않음(시간 별 예약 내역이 보이도록 수정)
 - reserve-calendar/page내 useQuery사용하는 구조로 변경
 - searchStore 생성해서 전역 상태로 관리하도록 수정


## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 추가 수정 사항

 - 날짜 빨간점 반응형 스타일 적용
 - 모바일일때 ‘예약현황’ sad laptop 이미지 가운데 정렬
 - 검색창, 예약현황-체험선택 등의 드롭다운 선택지 스타일(텍스트 사이즈 up, 구분선 추가, hover스타일 적용)
 - 모바일 일때 서치바 반응형 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 활동 예약 캘린더가 여러 달의 예약을 한 번에 불러오고, 날짜 선택 시 해당 날짜 예약만 표시합니다.
  - 날짜별로 여러 스케줄을 선택해 상세 예약 정보를 확인할 수 있습니다.
  - 활동 검색어/지역/카테고리 상태가 앱 전반에서 공유되어 페이지 이동 시에도 유지됩니다.
  - 로고 클릭 시 검색 상태가 초기화된 후 활동 목록으로 이동합니다.
  - 정렬·지역·카테고리 드롭다운이 옵션 선택 즉시 닫힙니다.
- Style
  - 드롭다운 버튼과 옵션에 클릭 가능 시각적 피드백(커서)이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->