### PR TITLE
🎨 style: 스타일 놓친 부분 fix

### DIFF
--- a/src/app/my/reservation/page.tsx
+++ b/src/app/my/reservation/page.tsx
@@ -3,7 +3,7 @@ import BookingList from '@/features/booking-detail/components/booking-list';
 const ReservationPage = () => {
   return (
     <main>
-      <div className="mb-[2.4rem] py-[1rem]">
+      <div className="pt-[1rem]">
         <h1 className="mb-[0.4rem] text-[1.8rem] font-bold text-gray-950">
           예약 내역
         </h1>

--- a/src/features/booking-detail/components/booking-list.tsx
+++ b/src/features/booking-detail/components/booking-list.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 
@@ -76,17 +75,7 @@ const BookingList = () => {
         ) : isError ? (
           <ErrorMessage />
         ) : filteredBookings.length === 0 ? (
-          <div className="flex-center flex-col gap-[1.6rem]">
-            <Image
-              src="/images/sad-laptop.svg"
-              alt="Sad laptop"
-              width={182}
-              height={182}
-            />
-            <p className="text-[1.6rem] font-medium text-gray-600">
-              조건에 맞는 예약 내역이 없어요.
-            </p>
-          </div>
+          <NoData message="조건에 맞는 예약 내역이 없어요." />
         ) : (
           <GroupedBookingCards reservations={filteredBookings} />
         )}

--- a/src/features/landing/components/hero.tsx
+++ b/src/features/landing/components/hero.tsx
@@ -91,7 +91,7 @@ const Hero = ({ swiperRef, ActivityCard, router }: HeroProps) => {
         </div>
         {/* Swiper/로딩/에러 분기 */}
         <div className="relative">
-          <div className="flex items-center justify-end md:mb-6 lg:mt-[5rem]">
+          <div className="mb-2.5 flex items-center justify-end md:mb-6 lg:mt-[5rem]">
             <div className="mr-[1rem] flex space-x-2">
               <button
                 onClick={() => swiperRef.current?.slidePrev()}


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약
랜딩페이지 - 모바일 - 캐러셀버튼 margin bottom 추가
예약내역 페이지 - sad laptop제거, NoData 적용, 불필요한 mb 스타일 삭제
<!-- 구현 내용or변경 사항에 대한 간단한 설명 -->
<!-- 관련 이슈는 development로 연결 또는 직접 작성( #issue, closes #issue ) -->

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 마이 예약 페이지 상단 여백을 조정해 헤더 아래 불필요한 공백을 줄였습니다. 화면 가독성과 공간 활용이 개선됩니다.
  - 랜딩 히어로 섹션의 내비게이션 버튼 영역 간격을 미세 조정해 요소 간 균형과 시각적 일관성을 높였습니다.
- 리팩터
  - 예약 목록의 필터링된 빈 상태 UI를 표준 NoData 컴포넌트로 교체해 메시지 표현을 통일하고 사용자 경험의 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->