### PR TITLE
♻️ refactor: 기존 서치바 모바일에서 오버플로우 나는 현상 틀 수정

### DIFF
--- a/src/features/activities/components/search.tsx
+++ b/src/features/activities/components/search.tsx
@@ -7,7 +7,6 @@ import React, { useEffect, useState } from 'react';
 import { getActListApi } from '@/features/activities/libs/api/getActListApi';
 import { useSearchStore } from '@/features/activities/libs/stores/searchStore';
 import Dropdown from '@/shared/components/dropdown/dropdown';
-import { Button } from '@/shared/components/modal/components/modal-button';
 import { searchVariant } from '@/shared/libs/constants/searchVariant';
 
 interface SearchProps {
@@ -83,7 +82,7 @@ const Search: React.FC<SearchProps> = ({
   return (
     <div className={style.wrapper}>
       <p className={style.title}>무엇을 체험하고 싶으신가요?</p>
-      <div className={style.inputBox + 'flex gap-2'}>
+      <div className={`${style.inputBox} flex items-center`}>
         <input
           type="text"
           value={keyword}
@@ -92,7 +91,7 @@ const Search: React.FC<SearchProps> = ({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           placeholder={isFocused ? '' : placeholder}
-          className={` ${style.input} `}
+          className={`${style.input} flex-1`}
         />
 
         <div className="mr-5 h-12 border-r border-gray-300"></div>
@@ -260,14 +259,13 @@ const Search: React.FC<SearchProps> = ({
           </Dropdown>
         </div>
 
-        <Button
-          color="blue"
-          ariaLabel="검색하기"
+        <button
+          type="button"
           onClick={handleSearch}
-          extraClassName={`${style.button} mx-7 flex items-center justify-center !w-[3rem] !h-[3rem] md:!w-[5rem] md:!h-[5rem] rounded-full`}
+          className="bg-main flex h-[3rem] w-[3rem] items-center justify-center rounded-full text-white transition-colors hover:bg-blue-600 md:h-[5rem] md:w-[5rem]"
         >
-          <SearchIcon className="h-8 w-8" />
-        </Button>
+          <SearchIcon className="h-5 w-5 md:h-6 md:w-6" />
+        </button>
       </div>
     </div>
   );

--- a/src/shared/libs/constants/searchVariant.ts
+++ b/src/shared/libs/constants/searchVariant.ts
@@ -1,12 +1,12 @@
 export const searchVariant = {
   main: {
     wrapper:
-      'flex-center flex-col gap-[1.2rem] py-[1.6rem] px-[2.4rem] md:py-[3.2rem] md:px-[4rem] md:gap-[3.6rem] mt-[1.2rem] lg:mt-[3rem]',
+      'flex-center flex-col gap-[1.2rem] py-[1.6rem] px-[1.2rem] md:py-[3.2rem] md:px-[4rem] md:gap-[3.6rem] mt-[1.2rem] lg:mt-[3rem]',
     title: 'font-bold text-[1.6rem] text-gray-950 md:text-[3.2rem] pb-[1rem]',
     inputBox:
-      'flex w-full sm:min-w-[32.7rem] sm:max-w-[70.4rem] md:min-w-[69.3rem] md:max-w-[92.9rem] lg:min-w-[92.9rem] lg:max-w-[104rem] h-[4.9rem] items-center rounded-full bg-white border focus-within:border-[#3D9EF2] py-[0.6rem] pr-[0.8rem] pl-[2rem] shadow-experience-card md:h-[7rem] md:py-[1rem] md:pr-[1.2rem] md:pl-[3.2rem]',
+      'flex w-full max-w-full sm:min-w-[32.7rem] sm:max-w-[70.4rem] md:min-w-[69.3rem] md:max-w-[92.9rem] lg:min-w-[92.9rem] lg:max-w-[104rem] h-[4.9rem] items-center rounded-full bg-white border focus-within:border-[#3D9EF2] py-[0.6rem] pr-[0.8rem] pl-[2rem] shadow-experience-card md:h-[7rem] md:py-[1rem] md:pr-[1.2rem] md:pl-[3.2rem]',
     input:
-      'txt-16-medium flex-1 px-5 text-black outline-none placeholder:text-gray-500 md:text-[1.8rem] caret-[#0094FF]',
+      'txt-16-medium px-5 text-black outline-none placeholder:text-gray-500 md:text-[1.8rem] caret-[#0094FF]',
     button:
       'font-bold bg-main h-[3.7rem] w-[8.5rem] rounded-full text-[1.4rem] text-white md:h-[5rem] md:w-[12rem] md:text-[1.6rem]',
   },


### PR DESCRIPTION
<!-- [깃모지 타입] -->
<!--  ✨Feat  🐛Fix  🎨Style  🗑️Remove  ♻️Refactor  📝Docs  🚀Deploy  -->
<!--  📁Chore : 폴더 구조 변경 또는 디렉토리 작업  🔧Chore : 설정, 빌드 변경  -->

## ✨ 요약

[mobile]
<img width="372" height="141" alt="image" src="https://github.com/user-attachments/assets/9edd58b5-ff77-4d84-85b9-e2edf259699a" />

[tablet]
<img width="383" height="103" alt="image" src="https://github.com/user-attachments/assets/bb0818ab-2396-4737-b5a5-66e6dba6f1c3" />

[pc]
<img width="1296" height="286" alt="image" src="https://github.com/user-attachments/assets/28d23b0d-67b1-4219-8a36-88e5ca54b3f1" />


## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [ ] 브랜치 네이밍 컨벤션을 준수했습니다
- [ ] 커밋 컨벤션을 준수했습니다
- [ ] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 검색 버튼을 네이티브 버튼으로 교체하고 크기, 호버, 반응형 스타일을 개선했습니다.
  * 검색 아이콘 크기를 뷰포트별로 조정했습니다.
  * 입력 컨테이너 정렬과 래퍼 패딩을 다듬고, 입력 필드의 확장 방식(max-width 추가, flex-1 제거)을 조정했습니다.

* 리팩터
  * 공용 버튼 의존성을 제거하여 단순화했으며, 검색 실행·이동 동작은 동일하게 유지됩니다.

* 접근성
  * 검색 버튼의 aria-label이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->